### PR TITLE
add hexagon grid page background option

### DIFF
--- a/app/src/main/java/com/ethran/notable/modals/NotebookConfig.kt
+++ b/app/src/main/java/com/ethran/notable/modals/NotebookConfig.kt
@@ -200,7 +200,8 @@ fun NotebookConfigDialog(bookId: String, onClose: () -> Unit) {
                                 "blank" to "Blank page",
                                 "dotted" to "Dot grid",
                                 "lined" to "Lines",
-                                "squared" to "Small squares grid"
+                                "squared" to "Small squares grid",
+                                "hexed" to "Hexagon grid",
                             ),
                             onChange = {
                                 if (book!!.defaultNativeTemplate != it) {

--- a/app/src/main/java/com/ethran/notable/modals/PageSettings.kt
+++ b/app/src/main/java/com/ethran/notable/modals/PageSettings.kt
@@ -65,7 +65,8 @@ fun PageSettingsModal(pageView: PageView, onClose: () -> Unit) {
                             "blank" to "Blank page",
                             "dotted" to "Dot grid",
                             "lined" to "Lines",
-                            "squared" to "Small squares grid"
+                            "squared" to "Small squares grid",
+                            "hexed" to "Hexagon grid",
                         ),
                         onChange = {
                             val updatedPage = pageView.pageFromDb!!.copy(nativeTemplate = it)

--- a/app/src/main/java/com/ethran/notable/utils/draw.kt
+++ b/app/src/main/java/com/ethran/notable/utils/draw.kt
@@ -32,6 +32,8 @@ import com.onyx.android.sdk.pen.NeoMarkerPen
 import io.shipbook.shipbooksdk.Log
 import kotlin.math.abs
 import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
 
 
 fun drawBallPenStroke(
@@ -223,6 +225,7 @@ fun drawImage(context: Context, canvas: Canvas, image: Image, offset: IntOffset)
 const val padding = 0
 const val lineHeight = 80
 const val dotSize = 6f
+const val hexVerticalCount = 26
 
 fun drawLinedBg(canvas: Canvas, scroll: Int, scale: Float) {
     val height = (canvas.height / scale).toInt()
@@ -309,12 +312,62 @@ fun drawSquaredBg(canvas: Canvas, scroll: Int, scale: Float) {
     }
 }
 
+fun drawHexedBg(canvas: Canvas, scroll: Int, scale: Float) {
+    val height = (canvas.height / scale)
+    val width = (canvas.width / scale)
+
+    // background
+    canvas.drawColor(Color.WHITE)
+
+    // stroke
+    val paint = Paint().apply {
+        this.color = Color.GRAY
+        this.strokeWidth = 1f
+        this.style = Paint.Style.STROKE
+    }
+
+    // https://www.redblobgames.com/grids/hexagons/#spacing
+    val r = height / (hexVerticalCount * 1.5f)
+    val hexHeight = r * 2
+    val hexWidth = r * sqrt(3f)
+
+    val rows = (height / hexVerticalCount).toInt()
+    val cols = (width / hexWidth).toInt()
+
+    for (row in 0..rows) {
+        val offsetX = if (row % 2 == 0) 0f else hexWidth / 2
+
+        for (col in 0..cols) {
+            val x = col * hexWidth + offsetX
+            val y = row * hexHeight * 0.75f - scroll.toFloat().mod(hexHeight * 1.5f)
+            drawHexagon(canvas, x, y, r, paint)
+        }
+    }
+}
+
+fun drawHexagon(canvas: Canvas, centerX: Float, centerY: Float, r: Float, paint: Paint) {
+    val path = Path()
+    for (i in 0..5) {
+        val angle = Math.toRadians((30 + 60 * i).toDouble())
+        val x = (centerX + r * cos(angle)).toFloat()
+        val y = (centerY + r * sin(angle)).toFloat()
+        if (i == 0) {
+            path.moveTo(x, y)
+        } else {
+            path.lineTo(x, y)
+        }
+    }
+    path.close()
+    canvas.drawPath(path, paint)
+}
+
 fun drawBg(canvas: Canvas, nativeTemplate: String, scroll: Int, scale: Float = 1f) {
     when (nativeTemplate) {
         "blank" -> canvas.drawColor(Color.WHITE)
         "dotted" -> drawDottedBg(canvas, scroll, scale)
         "lined" -> drawLinedBg(canvas, scroll, scale)
         "squared" -> drawSquaredBg(canvas, scroll, scale)
+        "hexed" -> drawHexedBg(canvas, scroll, scale)
     }
 
     // in landscape orientation add margin to indicate what will be visible in vertical orientation.

--- a/app/src/main/java/com/ethran/notable/utils/draw.kt
+++ b/app/src/main/java/com/ethran/notable/utils/draw.kt
@@ -32,6 +32,7 @@ import com.onyx.android.sdk.pen.NeoMarkerPen
 import io.shipbook.shipbooksdk.Log
 import kotlin.math.abs
 import kotlin.math.cos
+import kotlin.math.max
 import kotlin.math.sin
 import kotlin.math.sqrt
 
@@ -327,7 +328,7 @@ fun drawHexedBg(canvas: Canvas, scroll: Int, scale: Float) {
     }
 
     // https://www.redblobgames.com/grids/hexagons/#spacing
-    val r = height / (hexVerticalCount * 1.5f)
+    val r = max(width, height) / (hexVerticalCount * 1.5f)
     val hexHeight = r * 2
     val hexWidth = r * sqrt(3f)
 


### PR DESCRIPTION
I've added a hexagon grid background option. I've been using them myself for working with the Lumatone. I chose a size that roughly matches the other grids. Feel free to tweak.

Thoughts for future planning: As you're probably aware, if any of these background functions are updated, the backgrounds will likely be misaligned with the contents of existing pages. I think it'd be a good idea to store the parameters as well as the template names with the notebook or page to future-proof. 