### PR TITLE
Fix editor gesture handling and page view scrolling

### DIFF
--- a/app/src/main/java/com/ethran/notable/MainActivity.kt
+++ b/app/src/main/java/com/ethran/notable/MainActivity.kt
@@ -81,8 +81,10 @@ class MainActivity : ComponentActivity() {
         // Refactor - we prob don't need this
         EditorSettingCacheManager.init(applicationContext)
 
-        GlobalAppSettings.update(KvProxy(this).get("APP_SETTINGS", AppSettings.serializer())
-            ?: AppSettings(version = 1))
+        GlobalAppSettings.update(
+            KvProxy(this).get("APP_SETTINGS", AppSettings.serializer())
+                ?: AppSettings(version = 1)
+        )
 
         //EpdDeviceManager.enterAnimationUpdate(true);
 
@@ -120,6 +122,8 @@ class MainActivity : ComponentActivity() {
     override fun onPause() {
         super.onPause()
         this.lifecycleScope.launch {
+            Log.d("QuickSettings", "App is paused - maybe quick settings opened?")
+
             DrawCanvas.refreshUi.emit(Unit)
         }
     }
@@ -129,10 +133,15 @@ class MainActivity : ComponentActivity() {
         // It is really necessary?
         if (hasFocus) {
             enableFullScreen() // Re-apply full-screen mode when focus is regained
+            this.lifecycleScope.launch {
+                DrawCanvas.refreshUi.emit(Unit)
+            }
+        } else {
+            lifecycleScope.launch {
+                DrawCanvas.isDrawing.emit(false)
+            }
         }
-        this.lifecycleScope.launch {
-            DrawCanvas.refreshUi.emit(Unit)
-        }
+
     }
 
     // when the screen orientation is changed, set new screen width  restart is not necessary,

--- a/app/src/main/java/com/ethran/notable/classes/PageView.kt
+++ b/app/src/main/java/com/ethran/notable/classes/PageView.kt
@@ -412,6 +412,9 @@ class PageView(
         var delta = _delta
         if (scroll + delta < 0) delta = 0 - scroll
 
+        // There is nothing to do, return.
+        if (delta == 0) return
+
         scroll += delta
 
         // scroll bitmap


### PR DESCRIPTION
- Prevented editor gesture detection when the window loses focus.
- Prevented page view scrolling when delta is zero.
- disable drawing mode when window loses focus.