### PR TITLE
Continuous zoom -- finish implementation

### DIFF
--- a/app/src/main/java/com/ethran/notable/classes/EditorControlTower.kt
+++ b/app/src/main/java/com/ethran/notable/classes/EditorControlTower.kt
@@ -2,6 +2,7 @@ package com.ethran.notable.classes
 
 import android.content.Context
 import android.util.Log
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.toOffset
 import com.ethran.notable.TAG
@@ -69,10 +70,15 @@ class EditorControlTower(
         page.updatePageID(id)
     }
 
-    fun onPinchToZoom(delta: Float) {
+    fun onPinchToZoom(delta: Float, center: Offset?) {
+        // TODO: use center for drawing in right place.
+        //      For it to work, it needs to know scroll y -- so we need to transform scroll into OffSet
         scope.launch {
             scrollInProgress.withLock {
-                onPageZoom(delta)
+                if (GlobalAppSettings.current.simpleRendering)
+                    page.simpleUpdateZoom(delta)
+                else
+                    page.updateZoom(delta, Offset(0f,0f))
             }
             DrawCanvas.refreshUi.emit(Unit)
         }
@@ -115,9 +121,7 @@ class EditorControlTower(
             page.updateScroll(dragDelta)
     }
 
-    private suspend fun onPageZoom(delta: Float) {
-        page.updateZoom(delta)
-    }
+
 
     // when selection is moved, we need to redraw canvas
     fun applySelectionDisplace() {

--- a/app/src/main/java/com/ethran/notable/classes/GestureState.kt
+++ b/app/src/main/java/com/ethran/notable/classes/GestureState.kt
@@ -228,6 +228,26 @@ data class GestureState(
         return currentDistance / lastDistance - 1f
     }
 
+    /**
+     * Returns the current focal point (center) of the pinch gesture in screen coordinates.
+     */
+    fun getPinchCenter(): Offset? {
+        val src: Collection<Offset> = when {
+            lastPositions.size >= 2 -> lastPositions.values
+            initialPositions.size >= 2 -> initialPositions.values
+            else -> return null
+        }
+        var sumX = 0f
+        var sumY = 0f
+        var count = 0
+        for (p in src) {
+            sumX += p.x
+            sumY += p.y
+            count++
+        }
+        if (count < 2) return null
+        return Offset(sumX / count, sumY / count)
+    }
 
     fun isHolding(): Boolean {
         return if (getElapsedTime() >= HOLD_THRESHOLD_MS && getInputCount() == 1)


### PR DESCRIPTION
- added updateZoom function to reuse old bitmap for drawing on canvas, and only redraw missing parts. 
- old function handling zoom was renamed to simpleUpdateZoom

Missing: using actual position of fingers to determine witch part of screen to zoom into/out.