### PR TITLE
Improve UX of settings toggle with custom IconSwitch

### DIFF
--- a/app/src/main/java/com/ethran/notable/ui/components/Switch.kt
+++ b/app/src/main/java/com/ethran/notable/ui/components/Switch.kt
@@ -1,0 +1,141 @@
+package com.ethran.notable.ui.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+
+/**
+ * A custom switch composable that displays "ON" or "OFF" text inside the track.
+ *
+ * This switch animates its colors and thumb position based on the checked state, providing
+ * clear visual feedback. It is designed to mimic a physical toggle switch.
+ *
+ * @param modifier The [Modifier] to be applied to the switch.
+ * @param checked Whether the switch is in the 'on' or 'off' state.
+ * @param onCheckedChange A callback that is invoked when the user toggles the switch.
+ *                        The new checked state is passed as a parameter.
+ * @param enabled Controls the enabled state of the switch. When `false`, this switch will not
+ *                be interactive.
+ * @param animateTransition If `true`, the switch will animate color and position changes.
+ */
+@Composable
+fun OnOffSwitch(
+    modifier: Modifier = Modifier,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    enabled: Boolean = true,
+    animateTransition: Boolean = false,
+) {
+    // Dimensions
+    val trackWidth = 48.dp
+    val trackHeight = 20.dp
+    val thumbSize = 18.dp
+    val startOffset = 2.dp
+
+
+    val endOffset = trackWidth - thumbSize - startOffset
+    val safePad = thumbSize + 4.dp
+    val padStart = if (!checked) safePad else 6.dp
+    val padEnd = if (checked) safePad else 6.dp
+
+    // Color
+    val targetTrackColor =
+        if (checked) MaterialTheme.colors.onSurface else MaterialTheme.colors.surface
+    val targetThumbColor =
+        if (checked) MaterialTheme.colors.surface else MaterialTheme.colors.onSurface
+    val targetLabelColor =
+        if (checked) MaterialTheme.colors.surface else MaterialTheme.colors.onSurface
+    val targetThumbOffset = if (checked) endOffset else startOffset
+
+
+    val interactionSource = remember { MutableInteractionSource() }
+
+
+    // Animate or Set Values
+    val trackColor: Color by if (animateTransition) {
+        animateColorAsState(targetValue = targetTrackColor, label = "trackColor")
+    } else {
+        remember(targetTrackColor) { mutableStateOf(targetTrackColor) }
+    }
+
+    val thumbColor: Color by if (animateTransition) {
+        animateColorAsState(targetValue = targetThumbColor, label = "thumbColor")
+    } else {
+        remember(targetThumbColor) { mutableStateOf(targetThumbColor) }
+    }
+
+    val labelColor: Color by if (animateTransition) {
+        animateColorAsState(targetValue = targetLabelColor, label = "labelColor")
+    } else {
+        remember(targetLabelColor) { mutableStateOf(targetLabelColor) }
+    }
+
+    val thumbOffset: Dp by if (animateTransition) {
+        animateDpAsState(targetValue = targetThumbOffset, label = "thumbOffset")
+    } else {
+        remember(targetThumbOffset) { mutableStateOf(targetThumbOffset) }
+    }
+
+
+    Box(
+        modifier = modifier
+            .size(trackWidth, trackHeight)
+            .background(trackColor)
+            .toggleable(
+                value = checked,
+                enabled = enabled,
+                role = Role.Switch,
+                onValueChange = onCheckedChange,
+                interactionSource = interactionSource,
+                indication = null
+            )
+            .border(BorderStroke(1.dp, MaterialTheme.colors.onSurface)),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .padding(start = padStart, end = padEnd),
+            contentAlignment = if (checked) Alignment.CenterStart else Alignment.CenterEnd
+        ) {
+            Text(
+                text = if (checked) "ON" else "OFF",
+                color = labelColor,
+                fontSize = 10.sp,
+                style = MaterialTheme.typography.caption,
+                maxLines = 1
+            )
+        }
+
+        Surface(
+            color = thumbColor,
+            modifier = Modifier
+                .offset(x = thumbOffset)
+                .size(thumbSize)
+                .padding(2.dp)
+        ) {}
+    }
+}

--- a/app/src/main/java/com/ethran/notable/ui/dialogs/BackgroundSelector.kt
+++ b/app/src/main/java/com/ethran/notable/ui/dialogs/BackgroundSelector.kt
@@ -36,7 +36,6 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -85,6 +84,7 @@ import com.ethran.notable.editor.drawing.drawHexedBg
 import com.ethran.notable.editor.drawing.drawLinedBg
 import com.ethran.notable.editor.drawing.drawSquaredBg
 import com.ethran.notable.io.getPdfPageCount
+import com.ethran.notable.ui.components.OnOffSwitch
 import compose.icons.FeatherIcons
 import compose.icons.feathericons.Loader
 import io.shipbook.shipbooksdk.Log
@@ -276,7 +276,7 @@ fun BackgroundSelector(
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 Text("Repeat background")
                                 Spacer(Modifier.width(10.dp))
-                                Switch(
+                                OnOffSwitch(
                                     checked = pageBackgroundType == BackgroundType.ImageRepeating,
                                     onCheckedChange = { isChecked ->
                                         pageBackgroundType =

--- a/app/src/main/java/com/ethran/notable/ui/views/LogView.kt
+++ b/app/src/main/java/com/ethran/notable/ui/views/LogView.kt
@@ -33,7 +33,6 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -408,7 +407,7 @@ fun BugReportScreen(navController: NavController) {
         Spacer(Modifier.height(8.dp))
         // Include logs toggle
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Switch(
+            Checkbox(
                 checked = includeLogs,
                 onCheckedChange = { includeLogs = it }
             )

--- a/app/src/main/java/com/ethran/notable/ui/views/Settings.kt
+++ b/app/src/main/java/com/ethran/notable/ui/views/Settings.kt
@@ -2,13 +2,8 @@ package com.ethran.notable.ui.views
 
 import android.content.Context
 import android.content.Intent
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,12 +12,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
@@ -52,11 +45,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
@@ -66,6 +57,7 @@ import com.ethran.notable.data.datastore.AppSettings
 import com.ethran.notable.data.datastore.GlobalAppSettings
 import com.ethran.notable.data.db.KvProxy
 import com.ethran.notable.editor.ui.SelectMenu
+import com.ethran.notable.ui.components.OnOffSwitch
 import com.ethran.notable.ui.showHint
 import com.ethran.notable.utils.isLatestVersion
 import com.ethran.notable.utils.isNext
@@ -260,7 +252,7 @@ fun SettingToggleRow(
             color = MaterialTheme.colors.onSurface,
             maxLines = 2 // allow wrapping for long labels
         )
-        IconSwitch(
+        OnOffSwitch(
             checked = value,
             onCheckedChange = onToggle,
             modifier = Modifier.padding(start = 8.dp, top = 10.dp, bottom = 12.dp),
@@ -269,119 +261,6 @@ fun SettingToggleRow(
     SettingsDivider()
 }
 
-
-/**
- * A custom switch composable that displays "ON" or "OFF" text inside the track.
- *
- * This switch animates its colors and thumb position based on the checked state, providing
- * clear visual feedback. It is designed to mimic a physical toggle switch.
- *
- * @param modifier The [Modifier] to be applied to the switch.
- * @param checked Whether the switch is in the 'on' or 'off' state.
- * @param onCheckedChange A callback that is invoked when the user toggles the switch.
- *                        The new checked state is passed as a parameter.
- * @param enabled Controls the enabled state of the switch. When `false`, this switch will not
- *                be interactive.
- * @param animateTransition If `true`, the switch will animate color and position changes.
- */
-@Composable
-fun IconSwitch(
-    modifier: Modifier = Modifier,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
-    enabled: Boolean = true,
-    animateTransition: Boolean = false,
-) {
-    // Dimensions
-    val trackWidth = 48.dp
-    val trackHeight = 20.dp
-    val thumbSize = 18.dp
-    val startOffset = 2.dp
-
-
-    val endOffset = trackWidth - thumbSize - startOffset
-    val safePad = thumbSize + 4.dp
-    val padStart = if (!checked) safePad else 6.dp
-    val padEnd = if (checked) safePad else 6.dp
-
-    // Color
-    val targetTrackColor =
-        if (checked) MaterialTheme.colors.onSurface else MaterialTheme.colors.surface
-    val targetThumbColor =
-        if (checked) MaterialTheme.colors.surface else MaterialTheme.colors.onSurface
-    val targetLabelColor =
-        if (checked) MaterialTheme.colors.surface else MaterialTheme.colors.onSurface
-    val targetThumbOffset = if (checked) endOffset else startOffset
-
-
-    val interactionSource = remember { MutableInteractionSource() }
-
-
-    // Animate or Set Values
-    val trackColor: Color by if (animateTransition) {
-        animateColorAsState(targetValue = targetTrackColor, label = "trackColor")
-    } else {
-        remember(targetTrackColor) { mutableStateOf(targetTrackColor) }
-    }
-
-    val thumbColor: Color by if (animateTransition) {
-        animateColorAsState(targetValue = targetThumbColor, label = "thumbColor")
-    } else {
-        remember(targetThumbColor) { mutableStateOf(targetThumbColor) }
-    }
-
-    val labelColor: Color by if (animateTransition) {
-        animateColorAsState(targetValue = targetLabelColor, label = "labelColor")
-    } else {
-        remember(targetLabelColor) { mutableStateOf(targetLabelColor) }
-    }
-
-    val thumbOffset: Dp by if (animateTransition) {
-        animateDpAsState(targetValue = targetThumbOffset, label = "thumbOffset")
-    } else {
-        remember(targetThumbOffset) { mutableStateOf(targetThumbOffset) }
-    }
-
-
-    Box(
-        modifier = modifier
-            .size(trackWidth, trackHeight)
-            .background(trackColor)
-            .toggleable(
-                value = checked,
-                enabled = enabled,
-                role = Role.Switch,
-                onValueChange = onCheckedChange,
-                interactionSource = interactionSource,
-                indication = null
-            )
-            .border(BorderStroke(1.dp, MaterialTheme.colors.onSurface)),
-        contentAlignment = Alignment.CenterStart
-    ) {
-        Box(
-            modifier = Modifier
-                .matchParentSize()
-                .padding(start = padStart, end = padEnd),
-            contentAlignment = if (checked) Alignment.CenterStart else Alignment.CenterEnd
-        ) {
-            Text(
-                text = if (checked) "ON" else "OFF",
-                color = labelColor,
-                fontSize = 10.sp,
-                style = MaterialTheme.typography.caption,
-                maxLines = 1
-            )
-        }
-
-        Surface(
-            color = thumbColor,
-            modifier = Modifier
-                .offset(x = thumbOffset)
-                .size(thumbSize)
-                .padding(2.dp)
-        ) {}
-    }
-}
 
 @Composable
 fun TitleBar(navController: NavController) {


### PR DESCRIPTION
This pr should close #121. It replaces the default Material 2 Switch in settings rows with a custom IconSwitch that supports displaying icons inside the thumb. The new implementation provides clearer visual feedback while maintaining accessibility and theming consistency.
<img width="331" height="137" alt="image" src="https://github.com/user-attachments/assets/1914c304-1a57-49b7-bd63-8567528c239e" />
