### PR TITLE
Toolbar: Finish implementing Toolbar at the bottom.

### DIFF
--- a/app/src/main/java/com/ethran/notable/editor/ui/toolbar/EraserToolbarButton.kt
+++ b/app/src/main/java/com/ethran/notable/editor/ui/toolbar/EraserToolbarButton.kt
@@ -76,6 +76,7 @@ fun EraserToolbarButton(
             ) {
                 Column(
                     modifier = Modifier
+                        .padding(bottom = (BUTTON_SIZE + 5).dp) // For toolbar is located at the button,
                         .background(Color.White)
                         .border(1.dp, Color.Black)
                         .height(IntrinsicSize.Max)

--- a/app/src/main/java/com/ethran/notable/editor/ui/toolbar/Toolbar.kt
+++ b/app/src/main/java/com/ethran/notable/editor/ui/toolbar/Toolbar.kt
@@ -193,8 +193,8 @@ fun Toolbar(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .height((BUTTON_SIZE + 51).dp)
-                .padding(bottom = 50.dp) // TODO: fix this
+                .height((BUTTON_SIZE + 2).dp)
+                .padding(bottom = 1.dp)
         ) {
             if (GlobalAppSettings.current.toolbarPosition == AppSettings.Position.Bottom) {
                 Box(
@@ -511,6 +511,7 @@ fun Toolbar(
             )
         }
     } else {
+        // Button to show Toolbar
         ToolbarButton(
             onSelect = { state.isToolbarOpen = true },
             iconId = presentlyUsedToolIcon(state.mode, state.pen),
@@ -521,8 +522,8 @@ fun Toolbar(
             } else null,
             contentDescription = "open toolbar",
             modifier = Modifier
-                .height((BUTTON_SIZE + 51).dp)
-                .padding(bottom = 50.dp)
+                .height((BUTTON_SIZE + 1).dp)
+                .padding(bottom = 1.dp)
         )
     }
 }

--- a/app/src/main/java/com/ethran/notable/editor/ui/toolbar/ToolbarMenu.kt
+++ b/app/src/main/java/com/ethran/notable/editor/ui/toolbar/ToolbarMenu.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.navigation.NavController
 import com.ethran.notable.data.AppRepository
+import com.ethran.notable.data.datastore.BUTTON_SIZE
 import com.ethran.notable.editor.DrawCanvas.Companion.clearPageSignal
 import com.ethran.notable.editor.state.EditorState
 import com.ethran.notable.io.ExportEngine
@@ -55,12 +56,16 @@ fun ToolbarMenu(
     else page.parentFolderId
 
     Popup(
-        alignment = Alignment.TopEnd, onDismissRequest = { onClose() }, offset = IntOffset(
+        alignment = Alignment.TopEnd,
+        onDismissRequest = { onClose() },
+        offset = IntOffset(
             convertDpToPixel((-10).dp, context).toInt(), convertDpToPixel(50.dp, context).toInt()
-        ), properties = PopupProperties(focusable = true)
+        ),
+        properties = PopupProperties(focusable = true),
     ) {
         Column(
             Modifier
+                .padding(bottom = (BUTTON_SIZE + 5).dp) // For toolbar is located at the button,
                 .border(1.dp, Color.Black, RectangleShape)
                 .background(Color.White)
                 .width(IntrinsicSize.Max)

--- a/app/src/main/java/com/ethran/notable/ui/views/Settings.kt
+++ b/app/src/main/java/com/ethran/notable/ui/views/Settings.kt
@@ -171,7 +171,7 @@ fun GeneralSettings(kv: KvProxy, settings: AppSettings) {
                 kv.setAppSettings(settings.copy(defaultNativeTemplate = it))
             })
         SelectorRow(
-            label = "Toolbar Position (Work in progress)", options = listOf(
+            label = "Toolbar Position", options = listOf(
                 AppSettings.Position.Top to "Top", AppSettings.Position.Bottom to "Bottom"
             ), value = settings.toolbarPosition, onValueChange = { newPosition ->
                 settings.let {


### PR DESCRIPTION
- Adjust the position of the Stroke, Eraser, and Toolbar menus to prevent them from being obscured when the toolbar is at the bottom of the screen.
- Refactor `StrokeMenu` to reorder color and size pickers based on toolbar position.
- Remove hardcoded padding values in the main `Toolbar` composable.
- Update the "Toolbar Position" setting label, removing the "Work in progress" text.