### PR TITLE
Resize large images on import

### DIFF
--- a/app/src/main/java/com/ethran/notable/data/dbUtils.kt
+++ b/app/src/main/java/com/ethran/notable/data/dbUtils.kt
@@ -55,10 +55,11 @@ fun copyBackgroundToDatabase(context: Context, fileUri: Uri, subfolder: String):
     if (!outputDir.exists())
         outputDir.mkdirs()
     return if (isImageUri(context, fileUri))
-        // make sure that image is not too large
+    // make sure that image is not too large
         saveImageFromContentUri(context, fileUri, outputDir)
     else
-        createFileFromContentUri(context, fileUri, outputDir)}
+        createFileFromContentUri(context, fileUri, outputDir)
+}
 
 fun copyImageToDatabase(context: Context, fileUri: Uri, subfolder: String? = null): File {
     var outputDir = ensureImagesFolder()


### PR DESCRIPTION
When importing images, decode them to a capped resolution before saving to reduce file size and memory usage.

Should fix issue #190