### PR TITLE
Fix bug when the background wasn't loaded correctly on pdf change

### DIFF
--- a/app/src/main/java/com/ethran/notable/data/PageDataManager.kt
+++ b/app/src/main/java/com/ethran/notable/data/PageDataManager.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.launch
@@ -666,6 +665,16 @@ class PageDataManager @Inject constructor(
     }
 
     fun setBackground(pageId: String, background: CachedBackground) {
+        if (background.bitmap == null) {
+            val msg = "setBackground: skipping cache write, bitmap is null (id=${background.id})"
+            log.w(msg)
+            appEventBus.tryEmit(
+                AppEvent.GenericError(
+                    msg
+                )
+            )
+            return
+        }
         dataScope.launch {
             // we assume that the pageId is in current notebook.
             val observeBg = appRepository.isObservable(pageFromDb?.notebookId)
@@ -749,26 +758,38 @@ class PageDataManager @Inject constructor(
                         val eventString = fileObserverEventNames(event)
 
                         log.d("Background file changed: $filePath [event=$eventString]")
+
+                        // HANDLE DELETION / RE-REGISTRATION
                         if (event == DELETE || event == DELETE_SELF) {
-                            log.d("Background file deleted.")
+                            log.d("Background file deleted. Waiting for recreation...")
                             synchronized(fileObservers) {
                                 fileObservers.remove(filePath)?.stopWatching()
                             }
+
                             if (!waitForFileAvailable(filePath)) {
-                                log.w("File changed, but does not exist: $filePath")
+                                log.w("File disappeared and did not return: $filePath")
                                 appEventBus.tryEmit(
                                     AppEvent.ActionHint(
                                         "Background does not exist",
                                         3000
                                     )
                                 )
-                                return@launch
-                            } else
+                            } else {
+                                // RE-REGISTER: This starts a new observer on the new file handle
                                 observeBackgroundFile(pageId, filePath)
+                            }
+
+                            // IMPORTANT: Return here. Do NOT emit invalidateFileFlow.
+                            // We wait for the CLOSE_WRITE event from the NEW observer.
+                            return@launch
                         }
 
-
-                        invalidateFileFlow.emit(filePath)
+                        // HANDLE ACTUAL DATA UPDATES
+                        // Only emit when the file is ready to be read (CLOSE_WRITE or MOVED_TO)
+                        if (event == CLOSE_WRITE || event == MOVED_TO) {
+                            log.d("File is stable. Invalidating flow for: $filePath")
+                            invalidateFileFlow.emit(filePath)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/ethran/notable/io/FileUtils.kt
+++ b/app/src/main/java/com/ethran/notable/io/FileUtils.kt
@@ -18,6 +18,7 @@ import com.ethran.notable.SCREEN_HEIGHT
 import com.ethran.notable.SCREEN_WIDTH
 import com.ethran.notable.utils.logCallStack
 import com.onyx.android.sdk.utils.UriUtils.getDataColumn
+import io.shipbook.shipbooksdk.Log
 import io.shipbook.shipbooksdk.ShipBook
 import kotlinx.coroutines.delay
 import java.io.File
@@ -256,12 +257,14 @@ suspend fun waitForFileAvailable(
     var count = 1
     while (System.currentTimeMillis() - start < timeoutMs) {
         if (file.exists() && file.length() > 0) {
+            Log.d("waitForFileAvailable", "File available: $filePath, size=${file.length()}")
             return true
         }
         delay(intervalMs)
         intervalMs += count * count // Quadratic growth
         count++
     }
+    Log.d("waitForFileAvailable", "File not available: $filePath")
     return false
 }
 

--- a/app/src/main/java/com/ethran/notable/io/renderFromFile.kt
+++ b/app/src/main/java/com/ethran/notable/io/renderFromFile.kt
@@ -83,6 +83,6 @@ fun loadBackgroundBitmap(filePath: String, pageNumber: Int, scale: Float): Bitma
         renderPdfPageMuPdf(filePath, pageNumber, targetWidth.toInt(), resolutionModifier = 1.5f)
     else
         renderPdfPageAndroid(file, pageNumber, targetWidth.toInt(), resolutionModifier = 1.2f)
-    timer.end("loaded background")
+    timer.end("loaded background, newBitmap: $newBitmap")
     return newBitmap
 }


### PR DESCRIPTION
…en using observe pdf.

### Page Management & Backgrounds
- **PageDataManager**:
    - Added a safety check in `setBackground` to prevent writing null bitmaps to the cache and emit a `GenericError` event if encountered.
    - Enhanced `observeBackgroundFile` to handle file deletion and recreation more robustly. It now re-registers the `FileObserver` when a file is replaced.
    - Optimized `invalidateFileFlow` emissions to trigger only on `CLOSE_WRITE` or `MOVED_TO` events, ensuring file stability before background refreshes.
- **renderFromFile**: Added bitmap state information to the "loaded background" performance log.

### File Operations
- **FileUtils**:
    - Improved `waitForFileAvailable` with detailed logging for file existence and size updates during the polling period.

### Infrastructure
- Removed an unused `coroutineScope` import in `PageDataManager`.