### PR TITLE
Remove redundant default value handling from gesture settings UI. fix…

### DIFF
--- a/app/src/main/java/com/ethran/notable/data/datastore/AppSettings.kt
+++ b/app/src/main/java/com/ethran/notable/data/datastore/AppSettings.kt
@@ -48,13 +48,13 @@ data class AppSettings(
     val visualizePdfPagination: Boolean = false,
 
     // Gestures
-    val doubleTapAction: GestureAction? = defaultDoubleTapAction,
-    val twoFingerTapAction: GestureAction? = defaultTwoFingerTapAction,
-    val swipeLeftAction: GestureAction? = defaultSwipeLeftAction,
-    val swipeRightAction: GestureAction? = defaultSwipeRightAction,
-    val twoFingerSwipeLeftAction: GestureAction? = defaultTwoFingerSwipeLeftAction,
-    val twoFingerSwipeRightAction: GestureAction? = defaultTwoFingerSwipeRightAction,
-    val holdAction: GestureAction? = defaultHoldAction,
+    val doubleTapAction: GestureAction = GestureAction.Undo,
+    val twoFingerTapAction: GestureAction = GestureAction.ChangeTool,
+    val swipeLeftAction: GestureAction = GestureAction.NextPage,
+    val swipeRightAction: GestureAction = GestureAction.PreviousPage,
+    val twoFingerSwipeLeftAction: GestureAction = GestureAction.ToggleZen,
+    val twoFingerSwipeRightAction: GestureAction = GestureAction.ToggleZen,
+    val holdAction: GestureAction = GestureAction.Select,
     val enableQuickNav: Boolean = true,
     val renameOnCreate: Boolean = true,
 
@@ -69,17 +69,17 @@ data class AppSettings(
 
     ) {
     companion object {
-        val defaultDoubleTapAction get() = GestureAction.Undo
-        val defaultTwoFingerTapAction get() = GestureAction.ChangeTool
-        val defaultSwipeLeftAction get() = GestureAction.NextPage
-        val defaultSwipeRightAction get() = GestureAction.PreviousPage
-        val defaultTwoFingerSwipeLeftAction get() = GestureAction.ToggleZen
-        val defaultTwoFingerSwipeRightAction get() = GestureAction.ToggleZen
-        val defaultHoldAction get() = GestureAction.Select
+        val defaultDoubleTapAction = GestureAction.Undo
+        val defaultTwoFingerTapAction = GestureAction.ChangeTool
+        val defaultSwipeLeftAction = GestureAction.NextPage
+        val defaultSwipeRightAction = GestureAction.PreviousPage
+        val defaultTwoFingerSwipeLeftAction = GestureAction.ToggleZen
+        val defaultTwoFingerSwipeRightAction = GestureAction.ToggleZen
+        val defaultHoldAction = GestureAction.Select
     }
 
     enum class GestureAction {
-        Undo, Redo, PreviousPage, NextPage, ChangeTool, ToggleZen, Select
+        None, Undo, Redo, PreviousPage, NextPage, ChangeTool, ToggleZen, Select
     }
 
     enum class Position {

--- a/app/src/main/java/com/ethran/notable/gestures/EditorGestureReceiver.kt
+++ b/app/src/main/java/com/ethran/notable/gestures/EditorGestureReceiver.kt
@@ -39,13 +39,13 @@ fun EditorGestureReceiver(
     controlTower: EditorControlTower,
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val appSettings = remember { GlobalAppSettings.current }
+    val appSettings = GlobalAppSettings.current
     var crossPosition by remember { mutableStateOf<IntOffset?>(null) }
     var rectangleBounds by remember { mutableStateOf<Rect?>(null) }
     val view = LocalView.current
     Box(
         modifier = Modifier
-            .pointerInput(Unit) {
+            .pointerInput(appSettings) {
                 awaitEachGesture {
                     try {
                         // Detect initial touch
@@ -285,13 +285,13 @@ fun EditorGestureReceiver(
 private fun resolveGesture(
     settings: AppSettings?,
     default: AppSettings.GestureAction,
-    override: AppSettings.() -> AppSettings.GestureAction?,
+    override: AppSettings.() -> AppSettings.GestureAction,
     scope: CoroutineScope,
     rectangle: Rect = Rect(),
     controlTower: EditorControlTower
 ) {
     when (if (settings != null) override(settings) else default) {
-        null -> log.i("No Action")
+        AppSettings.GestureAction.None -> log.i("No Action")
         AppSettings.GestureAction.PreviousPage -> controlTower.goToPreviousPage()
 
         AppSettings.GestureAction.NextPage -> controlTower.goToNextPage()

--- a/app/src/main/java/com/ethran/notable/ui/components/GesturesSettings.kt
+++ b/app/src/main/java/com/ethran/notable/ui/components/GesturesSettings.kt
@@ -16,7 +16,7 @@ fun GesturesSettings(
     settings: AppSettings,
     onSettingsChange: (AppSettings) -> Unit,
     listOfGestures: List<GestureRowModel>,
-    availableGestures: List<Pair<AppSettings.GestureAction?, Any>>
+    availableGestures: List<Pair<AppSettings.GestureAction, Any>>
 ) {
     Column(
         modifier = Modifier
@@ -27,7 +27,6 @@ fun GesturesSettings(
             GestureSelectorRow(
                 title = stringResource(config.titleRes),
                 currentAction = config.currentValue,
-                defaultAction = config.defaultValue,
                 onActionSelected = { action -> config.onUpdate(action) },
                 availableGestures = availableGestures
             )
@@ -44,10 +43,9 @@ fun GesturesSettings(
 @Composable
 fun GestureSelectorRow(
     title: String,
-    currentAction: AppSettings.GestureAction?,
-    defaultAction: AppSettings.GestureAction,
-    onActionSelected: (AppSettings.GestureAction?) -> Unit,
-    availableGestures: List<Pair<AppSettings.GestureAction?, Any>>
+    currentAction: AppSettings.GestureAction,
+    onActionSelected: (AppSettings.GestureAction) -> Unit,
+    availableGestures: List<Pair<AppSettings.GestureAction, Any>>
 ) {
     // Map the Pair list to the format expected by SelectorRow
     val options = availableGestures.map { (action, resource) ->
@@ -62,7 +60,7 @@ fun GestureSelectorRow(
     SelectorRow(
         label = title,
         options = options,
-        value = currentAction ?: defaultAction,
+        value = currentAction,
         onValueChange = onActionSelected
     )
 }

--- a/app/src/main/java/com/ethran/notable/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/ethran/notable/ui/viewmodels/SettingsViewModel.kt
@@ -34,9 +34,8 @@ import javax.inject.Inject
 
 data class GestureRowModel(
     val titleRes: Int,
-    val currentValue: AppSettings.GestureAction?,
-    val defaultValue: AppSettings.GestureAction,
-    val onUpdate: (AppSettings.GestureAction?) -> Unit
+    val currentValue: AppSettings.GestureAction,
+    val onUpdate: (AppSettings.GestureAction) -> Unit
 )
 
 data class SyncSettingsUiState(
@@ -292,38 +291,32 @@ class SettingsViewModel @Inject constructor(
         GestureRowModel(
             R.string.gestures_double_tap_action,
             settings.doubleTapAction,
-            AppSettings.defaultDoubleTapAction
         ) { a -> updateSettings(settings.copy(doubleTapAction = a)) },
         GestureRowModel(
             (R.string.gestures_two_finger_tap_action),
             settings.twoFingerTapAction,
-            AppSettings.defaultTwoFingerTapAction,
         ) { a -> updateSettings(settings.copy(twoFingerTapAction = a)) },
         GestureRowModel(
             (R.string.gestures_swipe_left_action),
             settings.swipeLeftAction,
-            AppSettings.defaultSwipeLeftAction
         ) { a -> updateSettings(settings.copy(swipeLeftAction = a)) },
         GestureRowModel(
             (R.string.gestures_swipe_right_action),
             settings.swipeRightAction,
-            AppSettings.defaultSwipeRightAction
         ) { a -> updateSettings(settings.copy(swipeRightAction = a)) },
         GestureRowModel(
             (R.string.gestures_two_finger_swipe_left_action),
             settings.twoFingerSwipeLeftAction,
-            AppSettings.defaultTwoFingerSwipeLeftAction
         ) { a -> updateSettings(settings.copy(twoFingerSwipeLeftAction = a)) },
         GestureRowModel(
             R.string.gestures_two_finger_swipe_right_action,
             settings.twoFingerSwipeRightAction,
-            AppSettings.defaultTwoFingerSwipeRightAction
         ) { a -> updateSettings(settings.copy(twoFingerSwipeRightAction = a)) },
     )
 
 
     val availableGestures = listOf(
-        null to "None", // null represents no action
+        AppSettings.GestureAction.None to "None",
         AppSettings.GestureAction.Undo to R.string.gesture_action_undo,
         AppSettings.GestureAction.Redo to R.string.gesture_action_redo,
         AppSettings.GestureAction.PreviousPage to R.string.gesture_action_previous_page,

--- a/app/src/main/java/com/ethran/notable/ui/views/Settings.kt
+++ b/app/src/main/java/com/ethran/notable/ui/views/Settings.kt
@@ -91,7 +91,7 @@ fun SettingsView(
         viewModel.checkUpdate(context, force = false)
     }
 
-    @Suppress("KotlinConstantConditions") val versionString = remember {
+    val versionString = remember {
         "v${BuildConfig.VERSION_NAME}${if (isNext) " [NEXT]" else ""}"
     }
 

--- a/app/src/main/java/com/ethran/notable/ui/views/Settings.kt
+++ b/app/src/main/java/com/ethran/notable/ui/views/Settings.kt
@@ -138,7 +138,7 @@ fun SettingsContent(
     onUpdateSettings: (AppSettings) -> Unit,
     selectedTabInitial: Int = 0,
     listOfGestures: List<GestureRowModel> = emptyList(),
-    availableGestures: List<Pair<AppSettings.GestureAction?, Any>> = emptyList(),
+    availableGestures: List<Pair<AppSettings.GestureAction, Any>> = emptyList(),
     syncUiState: SyncSettingsUiState = SyncSettingsUiState(),
     syncCallbacks: SyncSettingsCallbacks = SyncSettingsCallbacks(),
 ) {
@@ -380,11 +380,10 @@ fun SettingsPreviewGeneral() {
 fun SettingsPreviewGestures() {
     val dummyRows = listOf(
         GestureRowModel(
-            R.string.gestures_double_tap_action, null, AppSettings.defaultDoubleTapAction
+            R.string.gestures_double_tap_action, AppSettings.GestureAction.None
         ) { }, GestureRowModel(
             R.string.gestures_two_finger_tap_action,
-            AppSettings.GestureAction.Undo,
-            AppSettings.defaultTwoFingerTapAction
+            AppSettings.GestureAction.Undo
         ) { })
     InkaTheme {
         SettingsContent(


### PR DESCRIPTION
… #273

### UI & ViewModels
- **SettingsViewModel**:
    - Removed the `defaultValue` property from the `GestureRowModel` data class.
    - Updated the `gestureRows` list to remove explicit default action assignments for various gesture types.
- **GesturesSettings**:
    - Removed the `defaultAction` parameter from the `GestureSelectorRow` composable.
    - Updated `SelectorRow` to use `currentAction` directly instead of falling back to a default value.
- **Settings (Views)**: Updated `SettingsPreviewGestures` to reflect the simplified `GestureRowModel` structure in UI previews.