### PR TITLE
QuickFix: enable JSON value coercion and bump to 0.2.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         minSdk 29
         targetSdk 35
 
-        versionCode 36
-        versionName '0.2.2'
+        versionCode 37
+        versionName '0.2.3'
         if (project.hasProperty('IS_NEXT') && project.property('IS_NEXT').toBoolean()) {
             def timestamp = new Date().format('dd.MM.YYYY-HH:mm')
             versionName = "${versionName}-next-${timestamp}"

--- a/app/src/main/java/com/ethran/notable/data/db/Kv.kt
+++ b/app/src/main/java/com/ethran/notable/data/db/Kv.kt
@@ -76,7 +76,6 @@ class KvRepository @Inject constructor(
 }
 
 
-
 /**
  * A high-level proxy for the Key-Value database.
  *
@@ -93,7 +92,10 @@ class KvProxy @Inject constructor(
     private val cryptoHelper: CryptoHelper
 ) {
     private val log = ShipBook.getLogger("KvProxy")
-    private val json = Json { ignoreUnknownKeys = true }
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
 
 
     suspend fun <T> get(key: String, serializer: KSerializer<T>): T? = withContext(Dispatchers.IO) {


### PR DESCRIPTION
### Build
- **app/build.gradle**: Incremented `versionCode` to 37 and updated `versionName` to 0.2.3.

### Core & Data
- **KvProxy**: Updated `Json` configuration to enable `coerceInputValues = true`, allowing the deserializer to use default values when encountering incompatible inputs.
- Cleaned up minor whitespace in `Kv.kt`.