### PR TITLE
Prevent startup crashes by refining storage checks and deferring data…

### DIFF
--- a/app/src/main/java/com/ethran/notable/MainActivity.kt
+++ b/app/src/main/java/com/ethran/notable/MainActivity.kt
@@ -47,7 +47,7 @@ import com.ethran.notable.ui.SnackState
 import com.ethran.notable.ui.SyncWorkUiBridge
 import com.ethran.notable.ui.components.NotableApp
 import com.ethran.notable.ui.theme.InkaTheme
-import com.ethran.notable.utils.hasFilePermission
+import com.ethran.notable.utils.hasUsableStorage
 import com.onyx.android.sdk.api.device.epd.EpdController
 import dagger.hilt.android.AndroidEntryPoint
 import io.shipbook.shipbooksdk.Log
@@ -133,7 +133,7 @@ class MainActivity : ComponentActivity() {
             var isInitialized by remember { mutableStateOf(false) }
 
             LaunchedEffect(Unit) {
-                if (hasFilePermission(this@MainActivity)) {
+                if (hasUsableStorage(this@MainActivity)) {
                     withContext(Dispatchers.IO) {
                         // Init app settings, also do migration
                         val savedSettings =

--- a/app/src/main/java/com/ethran/notable/data/db/Db.kt
+++ b/app/src/main/java/com/ethran/notable/data/db/Db.kt
@@ -7,7 +7,8 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverter
 import androidx.room.TypeConverters
-import com.ethran.notable.data.getDbDir
+import com.ethran.notable.data.dbDirPath
+import com.ethran.notable.data.getDbDirOrNull
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -45,7 +46,7 @@ class Converters {
     }
 
     @TypeConverter
-    fun toStrokePoints(bytes: ByteArray?): List<StrokePoint>? {
+    fun toStrokePoints(bytes: ByteArray?): List<StrokePoint> {
         if (bytes == null || bytes.isEmpty()) return emptyList()
         return decodeStrokePoints(bytes)
     }
@@ -120,7 +121,13 @@ object DatabaseModule {
         @ApplicationContext context: Context
     ): AppDatabase {
 
-        val dbDir = getDbDir()
+        // getDbDir() throws when storage isn't usable (permission revoked, storage not
+        // mounted yet, ...), which would crash Dagger's graph construction before the
+        // welcome screen ever gets a chance to render. Room doesn't open the database
+        // file until the first real query, and query paths verify storage access first
+        // (KvRepository, StrokeMigrationHelper), so fall back to the expected path and
+        // let the UI route to the welcome/setup screen instead.
+        val dbDir = getDbDirOrNull() ?: dbDirPath()
         val dbFile = File(dbDir, "app_database")
 
         return Room.databaseBuilder(

--- a/app/src/main/java/com/ethran/notable/data/dbUtils.kt
+++ b/app/src/main/java/com/ethran/notable/data/dbUtils.kt
@@ -15,25 +15,33 @@ import kotlinx.coroutines.withContext
 import java.io.File
 
 fun getDbDir(): File {
+    return getDbDirOrNull() ?: throw IllegalStateException(
+        "Database directory could not be created or is not writable at " +
+                "${dbDirPath().absolutePath}. " +
+                "Grant 'All files access' to Notable in system settings and restart the app."
+    )
+}
+
+/**
+ * Like [getDbDir], but returns null instead of throwing when the directory cannot be
+ * created or written to (missing permission, storage not mounted yet, etc.), so callers
+ * can fall back to the welcome/setup screen instead of crashing.
+ */
+fun getDbDirOrNull(): File? {
+    val dbDir = dbDirPath()
+    if (!dbDir.exists() && !dbDir.mkdirs() && !dbDir.exists()) return null
+    if (!dbDir.canWrite()) return null
+    return dbDir
+}
+
+/**
+ * The expected database directory path, without checking that it exists or is writable.
+ * Use [getDbDir] or [getDbDirOrNull] when actual access is needed.
+ */
+fun dbDirPath(): File {
     val documentsDir =
         Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
-    val dbDir = File(documentsDir, "notabledb")
-    if (!dbDir.exists()) {
-        val created = dbDir.mkdirs()
-        if (!created && !dbDir.exists()) {
-            throw IllegalStateException(
-                "Database directory could not be created at ${dbDir.absolutePath}. " +
-                "Grant 'All files access' to Notable in system settings and restart the app."
-            )
-        }
-    }
-    if (!dbDir.canWrite()) {
-        throw IllegalStateException(
-            "Database directory is not writable: ${dbDir.absolutePath}. " +
-            "Grant 'All files access' to Notable in system settings and restart the app."
-        )
-    }
-    return dbDir
+    return File(documentsDir, "notabledb")
 }
 
 fun ensureImagesFolder(): File {

--- a/app/src/main/java/com/ethran/notable/navigation/NotableNavigator.kt
+++ b/app/src/main/java/com/ethran/notable/navigation/NotableNavigator.kt
@@ -21,7 +21,7 @@ import com.ethran.notable.ui.views.LibraryDestination
 import com.ethran.notable.ui.views.PagesDestination
 import com.ethran.notable.ui.views.SystemInformationDestination
 import com.ethran.notable.ui.views.WelcomeDestination
-import com.ethran.notable.utils.hasFilePermission
+import com.ethran.notable.utils.hasUsableStorage
 import io.shipbook.shipbooksdk.ShipBook
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -37,14 +37,14 @@ fun rememberNotableAppState(
 ): NotableNavigator {
     val context = LocalContext.current
     return remember(navController, context, coroutineScope) {
-        NotableNavigator(navController, hasFilePermission(context), coroutineScope)
+        NotableNavigator(navController, hasUsableStorage(context), coroutineScope)
     }
 }
 
 @Stable
 class NotableNavigator(
     val navController: NavHostController,
-    private val hasFilePermission: Boolean,
+    private val hasUsableStorage: Boolean,
     private val coroutineScope: CoroutineScope
 ) {
     var isQuickNavOpen by mutableStateOf(false)
@@ -52,7 +52,7 @@ class NotableNavigator(
 
 
     val startDestination: String
-        get() = if (GlobalAppSettings.current.showWelcome || !hasFilePermission) WelcomeDestination.route
+        get() = if (GlobalAppSettings.current.showWelcome || !hasUsableStorage) WelcomeDestination.route
         else LibraryDestination.route
 
     val quickNavSourcePageId: String?

--- a/app/src/main/java/com/ethran/notable/ui/viewmodels/WelcomeViewModel.kt
+++ b/app/src/main/java/com/ethran/notable/ui/viewmodels/WelcomeViewModel.kt
@@ -3,16 +3,22 @@ package com.ethran.notable.ui.viewmodels
 import androidx.lifecycle.ViewModel
 import com.ethran.notable.data.datastore.GlobalAppSettings
 import com.ethran.notable.data.db.KvProxy
+import dagger.Lazy
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
 class WelcomeViewModel @Inject constructor(
-    private val kvProxy: KvProxy,
+    // Lazy: injecting KvProxy directly would force Room's AppDatabase to be built as soon
+    // as this ViewModel is constructed, i.e. as soon as the welcome screen appears - which
+    // is exactly the screen shown when storage permission (and therefore the db directory)
+    // isn't available yet. Deferring until removeWelcome() actually runs (only reachable
+    // once permission is granted) avoids that crash.
+    private val kvProxy: Lazy<KvProxy>,
 ) : ViewModel() {
 
     suspend fun removeWelcome() {
-        kvProxy.setAppSettings(
+        kvProxy.get().setAppSettings(
             GlobalAppSettings.current.copy(showWelcome = false)
         )
     }

--- a/app/src/main/java/com/ethran/notable/ui/views/WelcomeView.kt
+++ b/app/src/main/java/com/ethran/notable/ui/views/WelcomeView.kt
@@ -62,7 +62,7 @@ import com.ethran.notable.editor.utils.isRecommendedRefreshMode
 import com.ethran.notable.editor.utils.setRecommendedMode
 import com.ethran.notable.navigation.NavigationDestination
 import com.ethran.notable.ui.viewmodels.WelcomeViewModel
-import com.ethran.notable.utils.hasFilePermission
+import com.ethran.notable.utils.hasUsableStorage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -80,14 +80,14 @@ fun WelcomeView(
     val lifecycleOwner = LocalLifecycleOwner.current
     val scope = rememberCoroutineScope()
 
-    var filePermissionGranted by remember { mutableStateOf(hasFilePermission(context)) }
+    var filePermissionGranted by remember { mutableStateOf(hasUsableStorage(context)) }
     var recommendedRefreshMode by remember { mutableStateOf(isRecommendedRefreshMode()) }
     var refreshModeString by remember { mutableStateOf(getCurRefreshModeString()) }
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                filePermissionGranted = hasFilePermission(context)
+                filePermissionGranted = hasUsableStorage(context)
                 recommendedRefreshMode = isRecommendedRefreshMode()
                 refreshModeString = getCurRefreshModeString()
             }

--- a/app/src/main/java/com/ethran/notable/utils/checkPermissions.kt
+++ b/app/src/main/java/com/ethran/notable/utils/checkPermissions.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Environment
 import androidx.core.content.ContextCompat
+import com.ethran.notable.data.getDbDirOrNull
 
 /**
  * Returns true if the app has "full file access" for your current storage model:
@@ -25,6 +26,21 @@ fun hasFilePermission(context: Context): Boolean {
 
     // Skip permission check in automated tests to allow using in-memory components
     // without needing real storage permissions.
+    return isRunningAndroidTest()
+}
+
+/**
+ * Returns true only when the database directory is actually usable. The permission flag
+ * alone is not enough: isExternalStorageManager() can report true while the directory
+ * still can't be created or written (storage not mounted yet after boot, USB file
+ * transfer mode, ...). Callers gating database access should use this instead of
+ * [hasFilePermission] so failures route to the welcome/setup screen instead of crashing.
+ */
+fun hasUsableStorage(context: Context): Boolean {
+    if (!hasFilePermission(context)) return false
+    if (getDbDirOrNull() != null) return true
+    // In instrumented tests external storage may be unavailable; keep the same bypass
+    // hasFilePermission uses so in-memory components still work.
     return isRunningAndroidTest()
 }
 


### PR DESCRIPTION
…base initialization

This change ensures the app can safely launch and navigate to the welcome/setup screen even if storage permissions are missing or the filesystem is not yet writable (e.g., storage not mounted).

- **Refined storage validation**: Introduced `hasUsableStorage` which checks both the system permission and actual directory writability. This replaces the simpler `hasFilePermission` check in `MainActivity`, `NotableNavigator`, and `WelcomeView`.
- **Decoupled DB path from directory creation**: Refactored `dbUtils.kt` to separate path calculation (`dbDirPath`) from directory verification (`getDbDirOrNull`).
- **Resilient Database Injection**: Updated the Hilt provider for `AppDatabase` to fall back to the expected path if the directory isn't currently usable. Room does not open the database file until the first query, allowing the UI to route the user to the setup screen instead of crashing during Dagger graph construction.
- **Lazy ViewModel Dependencies**: Wrapped `KvProxy` in `Lazy` within `WelcomeViewModel`. This prevents the `AppDatabase` from being instantiated immediately when the welcome screen appears, avoiding crashes while the user is in the process of granting permissions.