### PR TITLE
Fix "frozen screen after selection" by synchronizing drawing state an…

### DIFF
--- a/app/src/main/java/com/ethran/notable/editor/canvas/OnyxInputHandler.kt
+++ b/app/src/main/java/com/ethran/notable/editor/canvas/OnyxInputHandler.kt
@@ -14,6 +14,7 @@ import com.ethran.notable.editor.utils.DeviceCompat
 import com.ethran.notable.editor.utils.Eraser
 import com.ethran.notable.editor.utils.Pen
 import com.ethran.notable.editor.utils.calculateBoundingBox
+import com.ethran.notable.editor.utils.cancelPendingScreenFreezeReset
 import com.ethran.notable.editor.utils.copyInput
 import com.ethran.notable.editor.utils.copyInputToSimplePointF
 import com.ethran.notable.editor.utils.enableNativeEraser
@@ -178,6 +179,9 @@ class OnyxInputHandler(
             enableNativeEraser(touchHelper)
             updatePenAndStroke()
         } else {
+            // A pending resetScreenFreeze resume would re-freeze the screen after we disable
+            // raw drawing (e.g. lasso select: the select-stroke refreshUi armed it) — kill it.
+            cancelPendingScreenFreezeReset()
             // Check if drawing is completed
             CanvasEventBus.waitForDrawing()
             // draw to view, before showing drawing, avoid stutter

--- a/app/src/main/java/com/ethran/notable/editor/utils/Select.kt
+++ b/app/src/main/java/com/ethran/notable/editor/utils/Select.kt
@@ -128,6 +128,11 @@ fun selectImagesAndStrokes(
     viewModel.selectionState.selectionDisplaceOffset = IntOffset(0, 0)
     viewModel.selectionState.placementMode = PlacementMode.Move
     viewModel.selectionState.holdRefresh()
+    // Exit drawing mode *before* the caller's refreshUi runs: setting it inside the launch
+    // below raced the Select-branch refreshUi in OnyxInputHandler, which then saw
+    // isDrawing==true, armed resetScreenFreeze's delayed resume, and re-froze the screen
+    // after updateIsDrawing() had disabled raw drawing — the "frozen after select" bug.
+    viewModel.setDrawingStateFromCanvas(false)
     page.drawAreaPageCoordinates(
         pageBounds,
         ignoredImageIds = imagesToSelect.map { it.id },
@@ -135,7 +140,6 @@ fun selectImagesAndStrokes(
 
     scope.launch {
         CanvasEventBus.refreshUi.emit(Unit)
-        viewModel.setDrawingStateFromCanvas(false)
     }
 }
 

--- a/app/src/main/java/com/ethran/notable/editor/utils/einkHelper.kt
+++ b/app/src/main/java/com/ethran/notable/editor/utils/einkHelper.kt
@@ -62,33 +62,33 @@ suspend fun waitForEpdRefresh(updateOption: UpdateOption = Device.currentDevice(
     when (updateOption) {
         UpdateOption.NORMAL -> {
             // HD mode
-            delay(190) // On my device ~160 is the minimal delay
+            delay(190.milliseconds) // On my device ~160 is the minimal delay
         }
 
         UpdateOption.REGAL -> {
             // regal mode
-            delay(180) // On my device ~150 is the minimal delay
+            delay(180.milliseconds) // On my device ~150 is the minimal delay
         }
 
         UpdateOption.FAST -> {
             //ultra fast, fast, balanced
-            delay(20) // 5ms is problematic sometimes on balanced mode.
+            delay(20.milliseconds) // 5ms is problematic sometimes on balanced mode.
         }
 
         UpdateOption.FAST_X -> {
             // no idea what it is
-            delay(4) // Minimal delay
+            delay(4.milliseconds) // Minimal delay
         }
 
         UpdateOption.FAST_QUALITY -> {
             // no idea what it is
-            delay(15)
+            delay(15.milliseconds)
         }
 
         else -> {
             // Default fallback
             log.e("Unknown refresh mode: $updateOption")
-            delay(10)
+            delay(10.milliseconds)
         }
     }
 }
@@ -233,6 +233,13 @@ fun partialRefreshRegionOnce(view: View, dirtyRect: Rect, touchHelper: TouchHelp
 // fresh 500 ms resume timer — the timers stack and "Resuming raw drawing" floods at the end.
 private val screenFreezeScope = CoroutineScope(Dispatchers.Default)
 private var screenFreezeResetJob: Job? = null
+
+// When raw drawing is being turned off entirely (e.g. entering selection), a pending resume
+// must not fire afterwards: its delayed isRawDrawingRenderEnabled=true would hand the screen
+// back to the firmware with input disabled — a frozen screen nothing unfreezes.
+fun cancelPendingScreenFreezeReset() {
+    screenFreezeResetJob?.cancel()
+}
 
 fun resetScreenFreeze(touchHelper: TouchHelper?, view: View? = null) {
     if(touchHelper == null) {


### PR DESCRIPTION
…d E-Ink resets

When transitioning from drawing to selection, a race condition allowed the E-Ink "screen freeze" (raw drawing mode) to be re-armed after drawing was disabled, resulting in a frozen display.

- **Synchronize drawing state in `Select.kt`**: Moved `viewModel.setDrawingStateFromCanvas(false)` out of the coroutine launch to ensure it executes before the UI refresh. This prevents `OnyxInputHandler` from seeing a stale "drawing" state and incorrectly arming a screen freeze reset.
- **Introduce `cancelPendingScreenFreezeReset`**: Added a utility to abort the `screenFreezeResetJob` in `einkHelper.kt`.
- **Prevent stale resets in `OnyxInputHandler`**: Explicitly cancel any pending screen freeze resumes when raw drawing is disabled (e.g., entering lasso select). This ensures a delayed resume cannot re-enable firmware-level raw drawing after the application has returned to standard UI rendering.