### PR TITLE
Refine pinch-to-zoom constraints to allow zooming while Select tool i…

### DIFF
--- a/app/src/main/java/com/ethran/notable/editor/EditorControlTower.kt
+++ b/app/src/main/java/com/ethran/notable/editor/EditorControlTower.kt
@@ -169,7 +169,10 @@ class EditorControlTower(
 
     override fun onPinchToZoom(delta: Float, center: Offset?) {
         if (!page.isTransformationAllowed) return
-        if (viewModel.toolbarState.value.mode == Mode.Select)
+        // Zooming under an active selection (floating bitmap, in-progress page
+        // cut) would desync the screen-space overlay from the strokes below it;
+        // with the select tool merely armed, zooming is fine.
+        if (viewModel.selectionState.isNonEmpty() || viewModel.selectionState.firstPageCut != null)
             return
         scope.launch {
             scrollInProgress.withLock {


### PR DESCRIPTION
…s armed

Zooming was previously disabled entirely while the toolbar was in Select mode. It is now permitted unless there is an active selection (floating bitmap) or an in-progress page cut, which would desync the screen-space overlay from the underlying strokes.