### PR TITLE
Extract per-pen Onyx stroke styles into StrokeStyleRegistry

### DIFF
--- a/app/src/main/java/com/ethran/notable/editor/drawing/StrokeStyleRegistry.kt
+++ b/app/src/main/java/com/ethran/notable/editor/drawing/StrokeStyleRegistry.kt
@@ -1,0 +1,61 @@
+package com.ethran.notable.editor.drawing
+
+import com.ethran.notable.editor.utils.Pen
+
+/**
+ * Which Onyx pen mechanism renders a stroke, plus the per-pen parameters that mechanism
+ * takes. This is the data the renderer's old `when(stroke.pen)` hardcoded; the renderer
+ * is now a thin executor of these values. Wrapper mechanics that never vary per pen
+ * (erase flags, matrix plumbing) stay in the executor.
+ */
+sealed interface OnyxStrokeStyle {
+    /** Plain canvas path (drawBallPenStroke) — no pressure, no texture. */
+    data object BallPen : OnyxStrokeStyle
+
+    /** NeoFountainPenV2Wrapper — pressure-sensitive width. */
+    data object Fountain : OnyxStrokeStyle
+
+    /** NeoBrushPenWrapper. */
+    data object Brush : OnyxStrokeStyle
+
+    /** NeoMarkerPenWrapper — flat translucent band. */
+    data object Marker : OnyxStrokeStyle
+
+    /** NeoCharcoalPenWrapper — textured pencil. */
+    data class Charcoal(val tiltEnabled: Boolean) : OnyxStrokeStyle
+}
+
+/**
+ * How a persisted stroke becomes pixels, per rendering backend. The app-backend side
+ * (perfect-freehand `OutlineOptions` presets) is added in Phase 2 of that plan; until
+ * then this carries only the Onyx style.
+ */
+data class StrokeStyle(
+    val onyx: OnyxStrokeStyle,
+)
+
+/**
+ * Pen -> StrokeStyle, keyed by the `stroke.pen` persisted in the DB. Serves the
+ * renderers (page load, scroll, undo — no toolbar exists in those code paths); the
+ * toolbar references pens by the same enum but never reads this registry.
+ *
+ * Adding a stroke-producing pen = one entry here (plus its toolbar element); the
+ * renderers need no edits. [StrokeStyleRegistryTest] fails if an entry is missing.
+ */
+object StrokeStyleRegistry {
+
+    private val styles: Map<Pen, StrokeStyle> = mapOf(
+        Pen.BALLPEN to StrokeStyle(OnyxStrokeStyle.BallPen),
+        Pen.REDBALLPEN to StrokeStyle(OnyxStrokeStyle.BallPen),
+        Pen.GREENBALLPEN to StrokeStyle(OnyxStrokeStyle.BallPen),
+        Pen.BLUEBALLPEN to StrokeStyle(OnyxStrokeStyle.BallPen),
+        Pen.FOUNTAIN to StrokeStyle(OnyxStrokeStyle.Fountain),
+        Pen.BRUSH to StrokeStyle(OnyxStrokeStyle.Brush),
+        Pen.MARKER to StrokeStyle(OnyxStrokeStyle.Marker),
+        Pen.PENCIL to StrokeStyle(OnyxStrokeStyle.Charcoal(tiltEnabled = true)),
+        // Pen.DASHED intentionally absent: erase-indicator only, never persisted as ink.
+    )
+
+    /** Null for pens that produce no persisted ink (DASHED). */
+    fun forPen(pen: Pen): StrokeStyle? = styles[pen]
+}

--- a/app/src/main/java/com/ethran/notable/editor/drawing/onyx/OnyxStrokeRenderer.kt
+++ b/app/src/main/java/com/ethran/notable/editor/drawing/onyx/OnyxStrokeRenderer.kt
@@ -5,9 +5,10 @@ import android.graphics.Matrix
 import android.graphics.Paint
 import androidx.compose.ui.geometry.Offset
 import com.ethran.notable.data.db.Stroke
+import com.ethran.notable.editor.drawing.OnyxStrokeStyle
 import com.ethran.notable.editor.drawing.StrokeRenderer
+import com.ethran.notable.editor.drawing.StrokeStyleRegistry
 import com.ethran.notable.editor.drawing.drawBallPenStroke
-import com.ethran.notable.editor.utils.Pen
 import com.ethran.notable.editor.utils.offsetStroke
 import com.onyx.android.sdk.data.note.ShapeCreateArgs
 import com.onyx.android.sdk.data.note.TouchPoint
@@ -23,6 +24,8 @@ private val strokeDrawingLogger = ShipBook.getLogger("OnyxStrokeRenderer")
 /**
  * Renders dry strokes with the Onyx SDK pen wrappers (NeoPen family). This is the only
  * renderer that speaks Onyx types; the TouchPoint conversion below is its private detail.
+ * Which wrapper a pen uses comes from [StrokeStyleRegistry] — this object only executes
+ * the style it is handed.
  */
 object OnyxStrokeRenderer : StrokeRenderer {
 
@@ -46,6 +49,12 @@ object OnyxStrokeRenderer : StrokeRenderer {
     }
 
     override fun drawStroke(canvas: Canvas, stroke: Stroke, offset: Offset) {
+        val style = StrokeStyleRegistry.forPen(stroke.pen)
+        if (style == null) {
+            strokeDrawingLogger.e("No stroke style for pen: ${stroke.pen}")
+            return
+        }
+
         val paint = Paint().apply {
             color = stroke.color
             this.strokeWidth = stroke.size
@@ -55,17 +64,15 @@ object OnyxStrokeRenderer : StrokeRenderer {
 
         // Trying to find what throws error when drawing quickly
         try {
-            when (stroke.pen) {
-                Pen.BALLPEN -> drawBallPenStroke(canvas, paint, stroke.size, positionedStroke.points)
-                Pen.REDBALLPEN -> drawBallPenStroke(canvas, paint, stroke.size, positionedStroke.points)
-                Pen.GREENBALLPEN -> drawBallPenStroke(canvas, paint, stroke.size, positionedStroke.points)
-                Pen.BLUEBALLPEN -> drawBallPenStroke(canvas, paint, stroke.size, positionedStroke.points)
+            // In-memory stroke pressure is normalized to [0,1] with maxPressure == 1
+            // (see Stroke.withNormalizedPressure). The wrappers take maxPressure as the
+            // pressure denominator, so passing stroke.maxPressure is a no-op divide for
+            // normalized strokes and stays correct for raw-scale ones.
+            when (val onyx = style.onyx) {
+                OnyxStrokeStyle.BallPen ->
+                    drawBallPenStroke(canvas, paint, stroke.size, positionedStroke.points)
 
-                // In-memory stroke pressure is normalized to [0,1] with maxPressure == 1
-                // (see Stroke.withNormalizedPressure). The wrappers take maxPressure as the
-                // pressure denominator, so passing stroke.maxPressure is a no-op divide for
-                // normalized strokes and stays correct for raw-scale ones.
-                Pen.FOUNTAIN -> {
+                OnyxStrokeStyle.Fountain -> {
                     NeoFountainPenV2Wrapper.drawStroke(
                         /* canvas = */ canvas,
                         /* paint = */ paint,
@@ -75,7 +82,7 @@ object OnyxStrokeRenderer : StrokeRenderer {
                     )
                 }
 
-                Pen.BRUSH -> {
+                OnyxStrokeStyle.Brush -> {
                     NeoBrushPenWrapper.drawStroke(
                         canvas,
                         paint,
@@ -86,7 +93,7 @@ object OnyxStrokeRenderer : StrokeRenderer {
                     )
                 }
 
-                Pen.MARKER -> {
+                OnyxStrokeStyle.Marker -> {
                     NeoMarkerPenWrapper.drawStroke(
                         canvas,
                         paint,
@@ -96,7 +103,7 @@ object OnyxStrokeRenderer : StrokeRenderer {
                     )
                 }
 
-                Pen.PENCIL -> {
+                is OnyxStrokeStyle.Charcoal -> {
                     // ShapeCreateArgs.maxPressure defaults to the device digitizer max; it is
                     // the divisor the charcoal renderer applies to point pressure, so it must
                     // match the scale the points are stored in.
@@ -107,15 +114,12 @@ object OnyxStrokeRenderer : StrokeRenderer {
                         .setPoints(strokeToTouchPoints(positionedStroke))
                         .setColor(stroke.color)
                         .setStrokeWidth(stroke.size)
-                        .setTiltEnabled(true)
+                        .setTiltEnabled(onyx.tiltEnabled)
                         .setErase(false)
                         .setCreateArgs(shapeArg)
                         .setRenderMatrix(Matrix())
                         .setScreenMatrix(Matrix())
                     NeoCharcoalPenWrapper.drawNormalStroke(arg)
-                }
-                else -> {
-                    strokeDrawingLogger.e("Unknown pen type: ${stroke.pen}")
                 }
             }
         } catch (e: Exception) {

--- a/app/src/test/java/com/ethran/notable/editor/drawing/StrokeStyleRegistryTest.kt
+++ b/app/src/test/java/com/ethran/notable/editor/drawing/StrokeStyleRegistryTest.kt
@@ -1,0 +1,28 @@
+package com.ethran.notable.editor.drawing
+
+import com.ethran.notable.editor.utils.Pen
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class StrokeStyleRegistryTest {
+
+    @Test
+    fun `every stroke-producing pen has a style`() {
+        for (pen in Pen.entries) {
+            if (pen == Pen.DASHED) continue
+            assertNotNull(
+                "Pen $pen produces persisted strokes and must have a StrokeStyle",
+                StrokeStyleRegistry.forPen(pen)
+            )
+        }
+    }
+
+    @Test
+    fun `the indicator-only DASHED pen has no style`() {
+        assertNull(
+            "DASHED is the erase indicator, never persisted ink — no style expected",
+            StrokeStyleRegistry.forPen(Pen.DASHED)
+        )
+    }
+}


### PR DESCRIPTION
OnyxStrokeRenderer's when(stroke.pen) branches become per-pen OnyxStrokeStyle data (BallPen/Fountain/Brush/Marker/Charcoal); the renderer is now a thin executor of the style it looks up. DASHED deliberately has no entry (erase indicator, never persisted ink) and the renderer logs-and-returns on a missing style. A unit test enforces that every stroke-producing Pen has a style.


Claude-Session: https://claude.ai/code/session_01QBvwzy7yksU6cnPUTsRZQ6