### PR TITLE
Harden crash handler: durable-first, startup cleanup, re-install over…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         minSdk 29
         targetSdk 35
 
-        versionCode 39
-        versionName '0.2.5'
+        versionCode 40
+        versionName '0.2.6'
         if (project.hasProperty('IS_NEXT') && project.property('IS_NEXT').toBoolean()) {
             def timestamp = new Date().format('dd.MM.YYYY-HH:mm')
             versionName = "${versionName}-next-${timestamp}"

--- a/app/src/androidTest/java/com/ethran/notable/editor/EditorSelectionThreadSafetyTests.kt
+++ b/app/src/androidTest/java/com/ethran/notable/editor/EditorSelectionThreadSafetyTests.kt
@@ -16,6 +16,7 @@ import com.ethran.notable.data.db.FolderRepository
 import com.ethran.notable.data.db.ImageRepository
 import com.ethran.notable.data.db.KvProxy
 import com.ethran.notable.data.db.KvRepository
+import com.ethran.notable.data.db.NotebookSyncStateRepository
 import com.ethran.notable.data.db.PageRepository
 import com.ethran.notable.data.db.Stroke
 import com.ethran.notable.data.db.StrokePoint
@@ -161,13 +162,16 @@ class EditorSelectionThreadSafetyTests {
         val kvRepository = KvRepository(db.kvDao(), context)
         val kvProxy = KvProxy(kvRepository, CryptoHelper())
 
+        val notebookSyncStateRepository = NotebookSyncStateRepository(db.notebookSyncStateDao())
         val appRepository = AppRepository(
             bookRepository = bookRepository,
             pageRepository = pageRepository,
             strokeRepository = strokeRepository,
             imageRepository = imageRepository,
             folderRepository = folderRepository,
+            notebookSyncStateRepository = notebookSyncStateRepository,
             kvProxy = kvProxy,
+            db = db,
         )
 
         val editorSettingCacheManager = EditorSettingCacheManager(kvRepository)

--- a/app/src/androidTest/java/com/ethran/notable/editor/EditorSimpleStateTests.kt
+++ b/app/src/androidTest/java/com/ethran/notable/editor/EditorSimpleStateTests.kt
@@ -13,6 +13,7 @@ import com.ethran.notable.data.db.FolderRepository
 import com.ethran.notable.data.db.ImageRepository
 import com.ethran.notable.data.db.KvProxy
 import com.ethran.notable.data.db.KvRepository
+import com.ethran.notable.data.db.NotebookSyncStateRepository
 import com.ethran.notable.data.db.PageRepository
 import com.ethran.notable.data.db.StrokeRepository
 import com.ethran.notable.editor.state.History
@@ -68,13 +69,16 @@ class EditorSimpleStateTests {
         val kvRepository = KvRepository(db.kvDao(), context)
         val kvProxy = KvProxy(kvRepository, CryptoHelper())
 
+        val notebookSyncStateRepository = NotebookSyncStateRepository(db.notebookSyncStateDao())
         val appRepository = AppRepository(
             bookRepository = bookRepository,
             pageRepository = pageRepository,
             strokeRepository = strokeRepository,
             imageRepository = imageRepository,
             folderRepository = folderRepository,
+            notebookSyncStateRepository = notebookSyncStateRepository,
             kvProxy = kvProxy,
+            db = db,
         )
 
         val editorSettingCacheManager = EditorSettingCacheManager(kvRepository)

--- a/app/src/androidTest/java/com/ethran/notable/editor/EditorUnsupportedConcurrentChangeTests.kt
+++ b/app/src/androidTest/java/com/ethran/notable/editor/EditorUnsupportedConcurrentChangeTests.kt
@@ -19,6 +19,7 @@ import com.ethran.notable.data.db.FolderRepository
 import com.ethran.notable.data.db.ImageRepository
 import com.ethran.notable.data.db.KvProxy
 import com.ethran.notable.data.db.KvRepository
+import com.ethran.notable.data.db.NotebookSyncStateRepository
 import com.ethran.notable.data.db.PageRepository
 import com.ethran.notable.data.db.Stroke
 import com.ethran.notable.data.db.StrokePoint
@@ -183,13 +184,16 @@ class EditorUnsupportedConcurrentChangeTests {
         val kvRepository = KvRepository(db.kvDao(), context)
         val kvProxy = KvProxy(kvRepository, CryptoHelper())
 
+        val notebookSyncStateRepository = NotebookSyncStateRepository(db.notebookSyncStateDao())
         val appRepository = AppRepository(
             bookRepository = bookRepository,
             pageRepository = pageRepository,
             strokeRepository = strokeRepository,
             imageRepository = imageRepository,
             folderRepository = folderRepository,
+            notebookSyncStateRepository = notebookSyncStateRepository,
             kvProxy = kvProxy,
+            db = db,
         )
 
         val editorSettingCacheManager = EditorSettingCacheManager(kvRepository)

--- a/app/src/androidTest/java/com/ethran/notable/io/XoppImportTest.kt
+++ b/app/src/androidTest/java/com/ethran/notable/io/XoppImportTest.kt
@@ -52,7 +52,7 @@ class XoppImportTest {
         db.close()
     }
 
-    @Test(timeout = 60000)
+    @Test(timeout = 120000)
     fun importNotableXopp_fromAssets_createsNotebookAndStrokes() = runBlocking {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val testContext = InstrumentationRegistry.getInstrumentation().context
@@ -98,7 +98,7 @@ class XoppImportTest {
         assertEquals("Notebook ID mismatch in page", book.id, db.pageDao().getById(importedPageIds.first())?.notebookId)
     }
     
-    @Test(timeout = 60000)
+    @Test(timeout = 120000)
     fun importNotableXopp_withExplicitTitle_stripsExtension() = runBlocking {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val testContext = InstrumentationRegistry.getInstrumentation().context
@@ -119,7 +119,7 @@ class XoppImportTest {
         assertNotNull("Should find notebook with stripped title", book)
     }
     
-    @Test(timeout = 60000)
+    @Test(timeout = 120000)
     fun importNotableXopp_verifiesDataIntegrity() = runBlocking {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val testContext = InstrumentationRegistry.getInstrumentation().context

--- a/app/src/main/java/com/ethran/notable/MainActivity.kt
+++ b/app/src/main/java/com/ethran/notable/MainActivity.kt
@@ -1,8 +1,11 @@
 package com.ethran.notable
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
@@ -46,6 +49,7 @@ import com.ethran.notable.ui.SnackDispatcher
 import com.ethran.notable.ui.SnackState
 import com.ethran.notable.ui.SyncWorkUiBridge
 import com.ethran.notable.ui.components.NotableApp
+import com.ethran.notable.ui.components.crashLogsAsText
 import com.ethran.notable.ui.theme.InkaTheme
 import com.ethran.notable.utils.hasUsableStorage
 import com.onyx.android.sdk.api.device.epd.EpdController
@@ -110,6 +114,7 @@ class MainActivity : ComponentActivity() {
         // outermost and still writes the durable crash file even if ShipBook doesn't chain back,
         // and flush any startup telemetry (crash-loop signal) that predated ShipBook being up.
         (application as? NotableApp)?.onShipBookStarted()
+        maybeShowCrashLoopHint()
 
         Log.i(TAG, "Notable started")
 
@@ -159,7 +164,6 @@ class MainActivity : ComponentActivity() {
                 }
                 isInitialized = true
             }
-
             InkaTheme {
                 CompositionLocalProvider(LocalSnackContext provides snackState) {
                     if (isInitialized) {
@@ -178,6 +182,31 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+
+    /**
+     * If startup detected a likely crash loop, show one dismissible snack with a "Copy logs" action
+     * that copies the local crash files to the clipboard. Simplest possible surface — the full
+     * viewer lives in Settings → Debug (Phase 8e-2). Returns whether a loop was detected (so a test
+     * harness can crash only on the non-recovery launch).
+     */
+    private fun maybeShowCrashLoopHint(): Boolean {
+        if ((application as? NotableApp)?.consumeCrashLoopDetected() != true) return false
+        snackDispatcher.showOrUpdateSnack(
+            SnackConf(
+                text = "Notable restarted after repeated crashes.",
+                duration = null, // stays until dismissed
+                actions = listOf(
+                    "Copy logs" to {
+                        val text = crashLogsAsText(this)
+                        getSystemService(ClipboardManager::class.java)
+                            ?.setPrimaryClip(ClipData.newPlainText("Notable crash logs", text))
+                        Toast.makeText(this, "Copied crash logs", Toast.LENGTH_SHORT).show()
+                    }
+                )
+            )
+        )
+        return true
+    }
 
     private fun triggerInitialSync() {
         lifecycleScope.launch {

--- a/app/src/main/java/com/ethran/notable/MainActivity.kt
+++ b/app/src/main/java/com/ethran/notable/MainActivity.kt
@@ -106,6 +106,9 @@ class MainActivity : ComponentActivity() {
         ShipBook.start(
             this.application, BuildConfig.SHIPBOOK_APP_ID, BuildConfig.SHIPBOOK_APP_KEY
         )
+        // ShipBook installs its own uncaught handler in start(); re-install ours on top so it is
+        // outermost and still writes the durable crash file even if ShipBook doesn't chain back.
+        (application as? NotableApp)?.reinstallCrashHandler()
 
         Log.i(TAG, "Notable started")
 

--- a/app/src/main/java/com/ethran/notable/MainActivity.kt
+++ b/app/src/main/java/com/ethran/notable/MainActivity.kt
@@ -107,8 +107,9 @@ class MainActivity : ComponentActivity() {
             this.application, BuildConfig.SHIPBOOK_APP_ID, BuildConfig.SHIPBOOK_APP_KEY
         )
         // ShipBook installs its own uncaught handler in start(); re-install ours on top so it is
-        // outermost and still writes the durable crash file even if ShipBook doesn't chain back.
-        (application as? NotableApp)?.reinstallCrashHandler()
+        // outermost and still writes the durable crash file even if ShipBook doesn't chain back,
+        // and flush any startup telemetry (crash-loop signal) that predated ShipBook being up.
+        (application as? NotableApp)?.onShipBookStarted()
 
         Log.i(TAG, "Notable started")
 

--- a/app/src/main/java/com/ethran/notable/NotableApp.kt
+++ b/app/src/main/java/com/ethran/notable/NotableApp.kt
@@ -6,7 +6,12 @@ import com.onyx.android.sdk.rx.RxManager
 import dagger.hilt.android.HiltAndroidApp
 import io.shipbook.shipbooksdk.ShipBook
 import org.lsposed.hiddenapibypass.HiddenApiBypass
+import java.io.BufferedWriter
 import java.io.File
+import java.io.FileWriter
+import java.io.PrintWriter
+import java.util.concurrent.atomic.AtomicInteger
+import androidx.core.content.edit
 
 @HiltAndroidApp
 class NotableApp : Application() {
@@ -14,9 +19,13 @@ class NotableApp : Application() {
     override fun onCreate() {
         Log.i("NotableApp", "onCreate START")
         super.onCreate()
-        logCrashLoopSignalOnStart()
-        pruneCrashFiles()
+        // Install first & synchronously so a crash during the rest of init is still caught.
         installCrashHandler()
+        // Small prefs I/O, kept on-thread: a fast startup crash must still update last_start or the
+        // next launch's crash-loop check misreads the interval.
+        logCrashLoopSignalOnStart()
+        // Pure cleanup (dir listing/sort/delete) — off the main thread to keep cold start cheap.
+        Thread { pruneCrashFiles() }.start()
         RxManager.Builder.initAppContext(this)
         checkHiddenApiBypass()
         Log.i("NotableApp", "onCreate FINISH")
@@ -32,11 +41,11 @@ class NotableApp : Application() {
      * Last-resort net for exceptions that escape a coroutine or the main thread. Without it they go
      * straight to the system "app has stopped" dialog with no telemetry. It records a crash-loop
      * marker, persists the stack to a local crash file (the durable record — survives when the
-     * network/heap is dead), best-effort logs to ShipBook, then **chains to the previous handler**
-     * so normal termination (and ShipBook's own crash reporting) still happens.
+     * network/heap is dead), logs to logcat, then **chains to the previous handler** so normal
+     * termination (and ShipBook's own async crash reporting) still happens.
      *
      * Installed here in `Application.onCreate` to cover early crashes, and **re-installed once more
-     * right after `ShipBook.start()` in MainActivity** ([reinstallCrashHandler]) so our handler is
+     * right after `ShipBook.start()` in MainActivity** ([onShipBookStarted]) so our handler is
      * outermost and is guaranteed to write the durable file even if an SDK replaces the handler
      * without chaining. The [alreadyHandled] guard makes the crash work run once even when two of
      * our handlers end up in the chain. See docs/crash-handling-plan.md, Phase 8.
@@ -54,16 +63,25 @@ class NotableApp : Application() {
                 return@UncaughtExceptionHandler
             }
             try {
-                // Durable-first: the cheapest durable signal before any heavy allocation, so an
-                // OutOfMemoryError while building the crash file can't cost us the crash-loop marker.
-                prefs().edit().putLong(KEY_LAST_CRASH, System.currentTimeMillis()).commit()
-                writeCrashFile(thread, throwable)
-                // Best-effort: ShipBook may not be started yet (it starts in MainActivity), and its
-                // queue is async — the local file above is the record we rely on.
-                ShipBook.getLogger("NotableApp")
-                    .e("Uncaught exception on thread '${thread.name}'", throwable)
+                // Each durable step is guarded independently so one failing (e.g. commit() throwing
+                // on a full disk, or an OOM building the file) can't skip the others. Durable-first:
+                // the tiny crash-loop marker before the larger file write.
+                try {
+                    prefs().edit(commit = true) { putLong(KEY_LAST_CRASH, System.currentTimeMillis()) }
+                } catch (t: Throwable) {
+                    Log.e("NotableApp", "crash marker failed", t)
+                }
+                try {
+                    writeCrashFile(thread, throwable)
+                } catch (t: Throwable) {
+                    Log.e("NotableApp", "crash file write failed", t)
+                }
+                // We do NOT call ShipBook here: its queue is async and the process dies as soon as we
+                // chain below, so it wouldn't flush. ShipBook's own handler (which we chain to) reports
+                // the exception; the local file above is our durable record. Logcat is synchronous.
+                Log.e("NotableApp", "Uncaught exception on thread '${thread.name}'", throwable)
             } catch (t: Throwable) {
-                // The handler must never throw — swallow anything here.
+                // The handler must never throw.
                 Log.e("NotableApp", "Crash handler itself failed", t)
             } finally {
                 previous?.uncaughtException(thread, throwable)
@@ -74,11 +92,26 @@ class NotableApp : Application() {
     }
 
     /**
-     * Re-install our handler after another SDK (ShipBook) has installed its own, so ours wraps it
-     * and is guaranteed to run. Idempotent: a no-op if our handler is already the current default.
-     * Call once from MainActivity immediately after `ShipBook.start()`.
+     * Call from MainActivity right after `ShipBook.start()`. Re-installs our handler on top of
+     * ShipBook's — **at most once ever** (so repeated Activity recreation can't grow an unbounded
+     * chain of wrapper handlers) — and flushes telemetry that couldn't reach ShipBook before it
+     * started.
      */
-    fun reinstallCrashHandler() = installCrashHandler()
+    fun onShipBookStarted() {
+        if (!reinstalledOverSdk) {
+            reinstalledOverSdk = true
+            installCrashHandler()
+        }
+        flushStartupTelemetry()
+    }
+
+    /** Report telemetry gathered before ShipBook was up (it starts in MainActivity, after onCreate). */
+    private fun flushStartupTelemetry() {
+        val loopMs = pendingCrashLoopMs ?: return
+        pendingCrashLoopMs = null
+        ShipBook.getLogger("NotableApp")
+            .w("Possible crash loop: previous run crashed $loopMs ms after launch")
+    }
 
     /** Records the throwable we last handled so the same crash isn't persisted twice when two of
      *  our handlers sit in the chain (onCreate + post-ShipBook). Returns true if already handled. */
@@ -94,12 +127,14 @@ class NotableApp : Application() {
             val p = prefs()
             val lastStart = p.getLong(KEY_LAST_START, 0L)
             val lastCrash = p.getLong(KEY_LAST_CRASH, 0L)
-            if (lastCrash > lastStart && lastStart > 0L && (lastCrash - lastStart) < CRASH_LOOP_MS) {
-                ShipBook.getLogger("NotableApp").w(
-                    "Possible crash loop: previous run crashed ${lastCrash - lastStart} ms after launch"
-                )
+            if (lastStart in 1..<lastCrash && (lastCrash - lastStart) < CRASH_LOOP_MS) {
+                val delta = lastCrash - lastStart
+                // ShipBook isn't started yet (it starts in MainActivity), so a ShipBook log here is
+                // dropped. Stash it for onShipBookStarted() to report, and log to logcat now.
+                pendingCrashLoopMs = delta
+                Log.w("NotableApp", "Possible crash loop: previous run crashed $delta ms after launch")
             }
-            p.edit().putLong(KEY_LAST_START, System.currentTimeMillis()).apply()
+            p.edit { putLong(KEY_LAST_START, System.currentTimeMillis()) }
         } catch (t: Throwable) {
             Log.w("NotableApp", "crash-loop check failed", t)
         }
@@ -107,14 +142,18 @@ class NotableApp : Application() {
 
     /**
      * Write one crash file. Kept minimal — no listing/sorting/deleting here (that runs at startup,
-     * [pruneCrashFiles]); the death path only creates the new file. The filename embeds the
-     * timestamp plus the thread id so two crashes in the same millisecond don't overwrite each other.
+     * [pruneCrashFiles]); the death path only creates the new file. The filename is
+     * `crash_<ts>_<seq>.txt`: the process-local counter disambiguates same-millisecond crashes
+     * without the deprecated, recyclable `Thread.id`. The stack is streamed straight to the file
+     * (no giant intermediate String) so this stays as OOM-safe as possible.
      */
     private fun writeCrashFile(thread: Thread, throwable: Throwable) {
         val dir = File(filesDir, CRASH_DIR).apply { mkdirs() }
-        File(dir, "crash_${System.currentTimeMillis()}_t${thread.id}.txt").writeText(
-            "thread=${thread.name}\n${throwable.stackTraceToString()}"
-        )
+        val file = File(dir, "crash_${System.currentTimeMillis()}_${crashSeq.incrementAndGet()}.txt")
+        PrintWriter(BufferedWriter(FileWriter(file))).use { pw ->
+            pw.println("thread=${thread.name}")
+            throwable.printStackTrace(pw)
+        }
     }
 
     /** Cap the crashes/ dir at startup, off the death path. Keeps the newest [MAX_CRASH_FILES] by
@@ -130,7 +169,7 @@ class NotableApp : Application() {
         }
     }
 
-    /** Parse the `<ts>` out of `crash_<ts>_t<id>.txt`; 0 sorts unparsable names as oldest. */
+    /** Parse the `<ts>` out of `crash_<ts>_<seq>.txt`; 0 sorts unparsable names as oldest. */
     private fun crashFileTimestamp(name: String): Long =
         name.removePrefix("crash_").substringBefore('_').toLongOrNull() ?: 0L
 
@@ -152,5 +191,17 @@ class NotableApp : Application() {
         // the crashing thread may not be the one that installed the handler.
         @Volatile
         private var lastHandled: Throwable? = null
+
+        // One-shot guard: our handler is re-installed over ShipBook's exactly once, so repeated
+        // Activity recreation can't grow an unbounded chain of wrapper handlers.
+        @Volatile
+        private var reinstalledOverSdk = false
+
+        // Crash-loop delta detected at startup before ShipBook was up; reported once ShipBook starts.
+        @Volatile
+        private var pendingCrashLoopMs: Long? = null
+
+        // Process-local counter for unique crash filenames (avoids the deprecated/recyclable Thread.id).
+        private val crashSeq = AtomicInteger(0)
     }
 }

--- a/app/src/main/java/com/ethran/notable/NotableApp.kt
+++ b/app/src/main/java/com/ethran/notable/NotableApp.kt
@@ -180,7 +180,9 @@ class NotableApp : Application() {
         private const val KEY_LAST_CRASH = "last_crash"
         private const val CRASH_LOOP_MS = 5_000L
         private const val MAX_CRASH_FILES = 20
-        private const val CRASH_DIR = "crashes"
+
+        /** Sub-directory of `filesDir` holding the crash files; read by the Settings crash-log viewer. */
+        const val CRASH_DIR = "crashes"
 
         // The handler instance we last installed, so a re-install can tell "already ours" from "an
         // SDK replaced it". @Volatile because it is read/written across threads.

--- a/app/src/main/java/com/ethran/notable/NotableApp.kt
+++ b/app/src/main/java/com/ethran/notable/NotableApp.kt
@@ -105,6 +105,16 @@ class NotableApp : Application() {
         flushStartupTelemetry()
     }
 
+    /**
+     * One-shot: true if this launch looked like a crash loop (the previous run crashed within
+     * [CRASH_LOOP_MS] of starting). The UI consumes it once to show a "copy crash logs" hint.
+     */
+    fun consumeCrashLoopDetected(): Boolean {
+        val detected = crashLoopDetected
+        crashLoopDetected = false
+        return detected
+    }
+
     /** Report telemetry gathered before ShipBook was up (it starts in MainActivity, after onCreate). */
     private fun flushStartupTelemetry() {
         val loopMs = pendingCrashLoopMs ?: return
@@ -132,6 +142,7 @@ class NotableApp : Application() {
                 // ShipBook isn't started yet (it starts in MainActivity), so a ShipBook log here is
                 // dropped. Stash it for onShipBookStarted() to report, and log to logcat now.
                 pendingCrashLoopMs = delta
+                crashLoopDetected = true
                 Log.w("NotableApp", "Possible crash loop: previous run crashed $delta ms after launch")
             }
             p.edit { putLong(KEY_LAST_START, System.currentTimeMillis()) }
@@ -202,6 +213,10 @@ class NotableApp : Application() {
         // Crash-loop delta detected at startup before ShipBook was up; reported once ShipBook starts.
         @Volatile
         private var pendingCrashLoopMs: Long? = null
+
+        // Set when startup detects a likely crash loop; consumed once by the UI to show a hint.
+        @Volatile
+        private var crashLoopDetected = false
 
         // Process-local counter for unique crash filenames (avoids the deprecated/recyclable Thread.id).
         private val crashSeq = AtomicInteger(0)

--- a/app/src/main/java/com/ethran/notable/NotableApp.kt
+++ b/app/src/main/java/com/ethran/notable/NotableApp.kt
@@ -14,6 +14,8 @@ class NotableApp : Application() {
     override fun onCreate() {
         Log.i("NotableApp", "onCreate START")
         super.onCreate()
+        logCrashLoopSignalOnStart()
+        pruneCrashFiles()
         installCrashHandler()
         RxManager.Builder.initAppContext(this)
         checkHiddenApiBypass()
@@ -27,22 +29,39 @@ class NotableApp : Application() {
     }
 
     /**
-     * Last-resort net for exceptions that escape a coroutine or the main thread. Without it they
-     * go straight to the system "app has stopped" dialog with no telemetry. We log to ShipBook,
-     * persist the stack to a local crash file (survives when the network/heap is dead), record a
-     * crash-loop signal, then **chain to the previous handler** (ShipBook installs its own) so
-     * normal termination still happens. See docs/crash-handling-plan.md, Layer 0.
+     * Last-resort net for exceptions that escape a coroutine or the main thread. Without it they go
+     * straight to the system "app has stopped" dialog with no telemetry. It records a crash-loop
+     * marker, persists the stack to a local crash file (the durable record — survives when the
+     * network/heap is dead), best-effort logs to ShipBook, then **chains to the previous handler**
+     * so normal termination (and ShipBook's own crash reporting) still happens.
+     *
+     * Installed here in `Application.onCreate` to cover early crashes, and **re-installed once more
+     * right after `ShipBook.start()` in MainActivity** ([reinstallCrashHandler]) so our handler is
+     * outermost and is guaranteed to write the durable file even if an SDK replaces the handler
+     * without chaining. The [alreadyHandled] guard makes the crash work run once even when two of
+     * our handlers end up in the chain. See docs/crash-handling-plan.md, Phase 8.
      */
     private fun installCrashHandler() {
         val previous = Thread.getDefaultUncaughtExceptionHandler()
-        logCrashLoopSignalOnStart()
+        // Nothing new to wrap (e.g. called twice with no SDK installing a handler in between).
+        if (previous === installedHandler) return
 
-        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+        val handler = Thread.UncaughtExceptionHandler { thread, throwable ->
+            // If an inner copy of our handler already did the durable work for this exact throwable,
+            // just chain — don't write a second file or re-commit the marker.
+            if (alreadyHandled(throwable)) {
+                previous?.uncaughtException(thread, throwable)
+                return@UncaughtExceptionHandler
+            }
             try {
+                // Durable-first: the cheapest durable signal before any heavy allocation, so an
+                // OutOfMemoryError while building the crash file can't cost us the crash-loop marker.
+                prefs().edit().putLong(KEY_LAST_CRASH, System.currentTimeMillis()).commit()
+                writeCrashFile(thread, throwable)
+                // Best-effort: ShipBook may not be started yet (it starts in MainActivity), and its
+                // queue is async — the local file above is the record we rely on.
                 ShipBook.getLogger("NotableApp")
                     .e("Uncaught exception on thread '${thread.name}'", throwable)
-                writeCrashFile(thread, throwable)
-                prefs().edit().putLong(KEY_LAST_CRASH, System.currentTimeMillis()).commit()
             } catch (t: Throwable) {
                 // The handler must never throw — swallow anything here.
                 Log.e("NotableApp", "Crash handler itself failed", t)
@@ -50,6 +69,23 @@ class NotableApp : Application() {
                 previous?.uncaughtException(thread, throwable)
             }
         }
+        Thread.setDefaultUncaughtExceptionHandler(handler)
+        installedHandler = handler
+    }
+
+    /**
+     * Re-install our handler after another SDK (ShipBook) has installed its own, so ours wraps it
+     * and is guaranteed to run. Idempotent: a no-op if our handler is already the current default.
+     * Call once from MainActivity immediately after `ShipBook.start()`.
+     */
+    fun reinstallCrashHandler() = installCrashHandler()
+
+    /** Records the throwable we last handled so the same crash isn't persisted twice when two of
+     *  our handlers sit in the chain (onCreate + post-ShipBook). Returns true if already handled. */
+    private fun alreadyHandled(throwable: Throwable): Boolean {
+        if (lastHandled === throwable) return true
+        lastHandled = throwable
+        return false
     }
 
     /** On startup, note if the last run crashed very soon after launching — a likely crash loop. */
@@ -69,15 +105,34 @@ class NotableApp : Application() {
         }
     }
 
+    /**
+     * Write one crash file. Kept minimal — no listing/sorting/deleting here (that runs at startup,
+     * [pruneCrashFiles]); the death path only creates the new file. The filename embeds the
+     * timestamp plus the thread id so two crashes in the same millisecond don't overwrite each other.
+     */
     private fun writeCrashFile(thread: Thread, throwable: Throwable) {
-        val dir = File(filesDir, "crashes").apply { mkdirs() }
-        // Cap the directory so crash files can't accumulate unbounded.
-        dir.listFiles()?.sortedByDescending { it.lastModified() }?.drop(MAX_CRASH_FILES - 1)
-            ?.forEach { it.delete() }
-        File(dir, "crash_${System.currentTimeMillis()}.txt").writeText(
+        val dir = File(filesDir, CRASH_DIR).apply { mkdirs() }
+        File(dir, "crash_${System.currentTimeMillis()}_t${thread.id}.txt").writeText(
             "thread=${thread.name}\n${throwable.stackTraceToString()}"
         )
     }
+
+    /** Cap the crashes/ dir at startup, off the death path. Keeps the newest [MAX_CRASH_FILES] by
+     *  the timestamp embedded in the filename (more reliable than File.lastModified, which can be 0). */
+    private fun pruneCrashFiles() {
+        try {
+            val files = File(filesDir, CRASH_DIR).listFiles() ?: return
+            files.sortedByDescending { crashFileTimestamp(it.name) }
+                .drop(MAX_CRASH_FILES)
+                .forEach { it.delete() }
+        } catch (t: Throwable) {
+            Log.w("NotableApp", "crash-file prune failed", t)
+        }
+    }
+
+    /** Parse the `<ts>` out of `crash_<ts>_t<id>.txt`; 0 sorts unparsable names as oldest. */
+    private fun crashFileTimestamp(name: String): Long =
+        name.removePrefix("crash_").substringBefore('_').toLongOrNull() ?: 0L
 
     private fun prefs() = getSharedPreferences("crash_guard", MODE_PRIVATE)
 
@@ -86,5 +141,16 @@ class NotableApp : Application() {
         private const val KEY_LAST_CRASH = "last_crash"
         private const val CRASH_LOOP_MS = 5_000L
         private const val MAX_CRASH_FILES = 20
+        private const val CRASH_DIR = "crashes"
+
+        // The handler instance we last installed, so a re-install can tell "already ours" from "an
+        // SDK replaced it". @Volatile because it is read/written across threads.
+        @Volatile
+        private var installedHandler: Thread.UncaughtExceptionHandler? = null
+
+        // The throwable last persisted, to dedupe when two of our handlers are chained. @Volatile:
+        // the crashing thread may not be the one that installed the handler.
+        @Volatile
+        private var lastHandled: Throwable? = null
     }
 }

--- a/app/src/main/java/com/ethran/notable/ui/components/CrashLogsSettings.kt
+++ b/app/src/main/java/com/ethran/notable/ui/components/CrashLogsSettings.kt
@@ -103,6 +103,10 @@ fun CrashLogsSettings() {
     }
 }
 
+/** Load + combine all crash files into one shareable/copyable string. Reusable outside Compose
+ *  (e.g. the crash-loop hint's "Copy logs" action). Small text files, so this is cheap. */
+internal fun crashLogsAsText(context: Context): String = combineForExport(loadCrashLogs(context))
+
 /** Newest-first; small text files, so reading them here is cheap (and this runs off the main thread). */
 private fun loadCrashLogs(context: Context): List<CrashLog> {
     val dir = File(context.filesDir, NotableApp.CRASH_DIR)

--- a/app/src/main/java/com/ethran/notable/ui/components/CrashLogsSettings.kt
+++ b/app/src/main/java/com/ethran/notable/ui/components/CrashLogsSettings.kt
@@ -1,0 +1,132 @@
+package com.ethran.notable.ui.components
+
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ethran.notable.NotableApp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+private data class CrashLog(val name: String, val content: String)
+
+/**
+ * Debug-tab section that surfaces the local crash files ([NotableApp] writes one per crash) so a
+ * user can read and **share** them when asked, instead of them being reachable only over adb.
+ * ShipBook is the automatic remote channel; this is the fallback for the cases ShipBook can't cover
+ * (network/heap dead, or a crash before ShipBook starts). Plan Phase 8e-1.
+ */
+@Composable
+fun CrashLogsSettings() {
+    val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
+    // Bumping this re-runs the loader (after a Clear).
+    var reload by remember { mutableIntStateOf(0) }
+
+    val logs by produceState(initialValue = emptyList<CrashLog>(), reload) {
+        value = withContext(Dispatchers.IO) { loadCrashLogs(context) }
+    }
+
+    Column(modifier = Modifier.padding(vertical = 8.dp)) {
+        Text(
+            text = "Crash logs (${logs.size})",
+            style = MaterialTheme.typography.subtitle1
+        )
+        Spacer(Modifier.height(4.dp))
+
+        if (logs.isEmpty()) {
+            Text(
+                text = "No crash logs — nothing has crashed since the last clear.",
+                style = MaterialTheme.typography.caption,
+                color = MaterialTheme.colors.onSurface.copy(alpha = 0.5f)
+            )
+            return@Column
+        }
+
+        val combined = remember(logs) { combineForExport(logs) }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(220.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                text = combined,
+                style = TextStyle(fontFamily = FontFamily.Monospace, fontSize = 10.sp),
+                color = MaterialTheme.colors.onSurface
+            )
+        }
+
+        Spacer(Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = {
+                clipboard.setText(AnnotatedString(combined))
+                Toast.makeText(context, "Copied crash logs", Toast.LENGTH_SHORT).show()
+            }) { Text("Copy") }
+
+            Button(onClick = { shareText(context, combined) }) { Text("Share") }
+
+            Button(onClick = {
+                clearCrashLogs(context)
+                reload++
+            }) { Text("Clear") }
+        }
+    }
+}
+
+/** Newest-first; small text files, so reading them here is cheap (and this runs off the main thread). */
+private fun loadCrashLogs(context: Context): List<CrashLog> {
+    val dir = File(context.filesDir, NotableApp.CRASH_DIR)
+    val files = dir.listFiles()?.sortedByDescending { it.name } ?: return emptyList()
+    return files.map { file ->
+        val content = runCatching { file.readText() }.getOrElse { "<unreadable: ${it.message}>" }
+        CrashLog(file.name, content)
+    }
+}
+
+private fun combineForExport(logs: List<CrashLog>): String =
+    logs.joinToString("\n\n") { "──── ${it.name} ────\n${it.content}" }
+
+private fun shareText(context: Context, text: String) {
+    val send = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_SUBJECT, "Notable crash logs")
+        putExtra(Intent.EXTRA_TEXT, text)
+    }
+    context.startActivity(Intent.createChooser(send, "Share crash logs"))
+}
+
+private fun clearCrashLogs(context: Context) {
+    runCatching {
+        File(context.filesDir, NotableApp.CRASH_DIR).listFiles()?.forEach { it.delete() }
+    }
+}

--- a/app/src/main/java/com/ethran/notable/ui/components/DebugSettings.kt
+++ b/app/src/main/java/com/ethran/notable/ui/components/DebugSettings.kt
@@ -61,5 +61,6 @@ fun DebugSettings(
                 onSettingsChange(settings.copy(destructiveMigrations = isChecked))
             }
         )
+        CrashLogsSettings()
     }
 }


### PR DESCRIPTION
… ShipBook

Phase 8 of the crash-handling plan (from a code review of the Phase 0a handler):

- 8a durable-first: commit the crash-loop marker BEFORE the allocation-heavy writeCrashFile, so a secondary OOM while building the stack string can't cost us the loop signal.
- 8b move dir-capping out of the death path to startup (pruneCrashFiles in onCreate), and select prune candidates by the timestamp embedded in the filename instead of File.lastModified() (drops a syscall and the 0L-on-error case).
- 8c collision-proof filename: crash_<ts>_t<threadId>.txt so two crashes in the same millisecond don't overwrite.
- 8d close the install-order gap: the handler is installed in Application.onCreate but ShipBook.start runs later in MainActivity, so our comment "ShipBook installs its own" was wrong and we depended on ShipBook chaining back. Re-install ours right after ShipBook.start so it is outermost and always writes the durable file; an alreadyHandled per-throwable guard dedupes when both handlers end up chained. ShipBook logging is now explicitly best-effort (may not be started for early crashes) — the local file is the record we rely on.

