### PR TITLE
Clear the QuickNav scrubber when the page changes

### DIFF
--- a/app/src/main/java/com/ethran/notable/ui/components/QuickNav.kt
+++ b/app/src/main/java/com/ethran/notable/ui/components/QuickNav.kt
@@ -80,7 +80,18 @@ fun QuickNav(
     })
 
     // Observe the UI State lifecycle-safely
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val collectedState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // The sheet composes before the effect below runs, so on the first frame the state still
+    // describes the page QuickNav was last opened on. Drop the scrubber until the state catches
+    // up, rather than drawing one for the previous notebook and removing it a frame later.
+    val uiState = if (collectedState.currentPageId == currentPageId) collectedState
+    else collectedState.copy(
+        bookPageCount = 0,
+        currentBookIndex = 0,
+        favoriteIndexesInBook = emptyList(),
+        bookPageIds = emptyList(),
+    )
 
     // Load data when the page changes
     LaunchedEffect(currentPageId) {

--- a/app/src/main/java/com/ethran/notable/ui/viewmodels/QuickNavViewModel.kt
+++ b/app/src/main/java/com/ethran/notable/ui/viewmodels/QuickNavViewModel.kt
@@ -56,7 +56,21 @@ class QuickNavViewModel(
     fun loadPageData(currentPageId: String?) {
         if (currentPageId == null) return
 
-        _uiState.update { it.copy(isLoading = true, currentPageId = currentPageId) }
+        _uiState.update {
+            it.copy(
+                isLoading = true,
+                currentPageId = currentPageId,
+                // Clear the scrubber, which describes the notebook we are leaving. loadBookData
+                // below writes these only for a notebook of two or more pages, and nothing else
+                // resets them, so without this they survive onto a shorter notebook, or onto a
+                // quick page that has no notebook at all, and the scrubber is drawn with the
+                // previous notebook's page count.
+                bookPageCount = 0,
+                currentBookIndex = 0,
+                favoriteIndexesInBook = emptyList(),
+                bookPageIds = emptyList(),
+            )
+        }
 
         viewModelScope.launch(Dispatchers.IO) {
             val page = runCatching { pageRepository.getById(currentPageId) }.getOrNull()


### PR DESCRIPTION
`loadBookData` writes the scrubber fields only when a notebook has 2+ pages, and nothing ever resets them, so they survive onto a page that should have no scrubber.

**Repro:** open QuickNav on a notebook with 2+ pages, dismiss it, open a quick page, then open QuickNav again. The scrubber is still drawn, showing the previous notebook's page count. It persists for the session, because the ViewModel outlives the sheet.

The fix clears those fields in `loadPageData` alongside the other per-page state. The sheet composes before that effect runs, so it would otherwise draw the stale scrubber for one frame and then remove it. The scrubber is therefore also suppressed until the state describes the page being opened.

That second part points at something wider. The sheet's state is a set of correlated fields that can describe a different page than the one on screen. Deriving the state from the page, rather than loading into it, would remove the whole class of problem.

Split out of #311. Verified on a Go 10.3 before and after.

Written with AI assistance (Claude), recorded in the commit trailer.
